### PR TITLE
Changed NorESM specific server for input data.

### DIFF
--- a/config/cesm/config_inputdata.xml
+++ b/config/cesm/config_inputdata.xml
@@ -6,7 +6,7 @@
   
   <server>
     <protocol>wget</protocol>
-    <address>http://ns2345k.web.sigma2.no/inputdata</address>
+    <address>https://www.noresm.org/inputdata</address>
   </server>
   
   <server>


### PR DESCRIPTION
Set the NorESM server for input data to https://www.noresm.org/inputdata. This address is currently forwarding to http://ns9560k.web.sigma2.no/inputdata. I have verified that missing input data reported by $CASEROOT/check_input_data are correctly downloaded using $CASEROOT/check_input_data --download.