### PR TITLE
Fix missing prognostic CO2 coupling field for emission driven compsets

### DIFF
--- a/src/drivers/mct/shr/seq_flds_mod.F90
+++ b/src/drivers/mct/shr/seq_flds_mod.F90
@@ -2468,6 +2468,7 @@ contains
 
        call seq_flds_add(a2x_states, "Sa_co2prog")
        call seq_flds_add(x2l_states, "Sa_co2prog")
+       call seq_flds_add(x2o_states, "Sa_co2prog")
        longname = 'Prognostic CO2 at the lowest model level'
        stdname  = ''
        units    = '1e-6 mol/mol'


### PR DESCRIPTION
Add prognostic CO2 at lowest model level to ocean coupling fields if option CO2_DMSA is activated (for emission driven NorESM2 compsets). All emission driven CMIP6 runs have been performed with this fix in SourceMods. I should be included in release 2.0.2

