### PR TITLE
Activated for CAM on fram/vilje : -init=zero,arrays

### DIFF
--- a/config/cesm/machines/config_compilers.xml
+++ b/config/cesm/machines/config_compilers.xml
@@ -1186,6 +1186,7 @@ using a fortran linker.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 -xAVX </append>
     <append MODEL="blom"> -r8 </append>
+    <append MODEL="cam"> -init=zero,arrays </append>
   </FFLAGS>
   <PIO_FILESYSTEM_HINTS>lustre</PIO_FILESYSTEM_HINTS>
   <SLIBS>
@@ -1207,6 +1208,7 @@ using a fortran linker.
   <FFLAGS>
     <append DEBUG="FALSE"> -O2 </append>
     <append MODEL="blom"> -r8 </append>
+    <append MODEL="cam"> -init=zero,arrays </append>
   </FFLAGS>
   <MPICC> mpiicc </MPICC>
   <MPICXX> mpiicpc </MPICXX>

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -875,7 +875,7 @@ class Case(object):
 
         if not test and not run_unsupported and self._cime_model == "cesm":
             if grid_name in science_support:
-                logger.info("\nThis is a CESM scientifically supported compset at this resolution.\n")
+                logger.info("\nThis is a CESM or NorESM scientifically supported compset at this resolution.\n")
             else:
                 self._check_testlists(compset_alias, grid_name, files)
 


### PR DESCRIPTION
[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.
Lines should be wrapped at about 72 characters. Please also update
the CIME documentation, if necessary, in doc/source/rst and indicate
below if you need to have the gh-pages html regenerated.]

Test suite: 
Test baseline: N1850_f19_tn14_20190621
Test namelist changes: 
Test status: [bit for bit, roundoff, climate changing] bit for bit on fram only obtained when setting for CAM : -init=zero,arrays

Fixes [CIME Github issue #] : NorESM issue 116

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
