### PR TITLE
Add PnetCDF module for Betzy settings.

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2900,6 +2900,7 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">StdEnv</command>
         <command name="load">intel/2020a</command>
         <command name="load">netCDF-Fortran/4.5.2-iompi-2020a</command>
+        <command name="load">PnetCDF/1.12.1-iompi-2020a</command>
         <command name="load">iompi/2020a</command>
         <command name="load">CMake/3.12.1</command>
       </modules>


### PR DESCRIPTION
Would it be possible to add a PnetCDF module for Betzy? BLOM breaks when setting `IOTYPE=1` (use pnetcdf), it would be nice if this could be fixed. I tested the `1.12.1-iompi-2020a` version, that seems to work.