### PR TITLE
ocn_surface_flux_scheme=1 by default for NorESM compsets

### DIFF
--- a/src/drivers/mct/cime_config/buildnml
+++ b/src/drivers/mct/cime_config/buildnml
@@ -40,6 +40,7 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
     config['CPL_ALBAV'] = case.get_value('CPL_ALBAV')
 #+tht
     config['COSZ_AVG'] = case.get_value('COSZ_AVG')
+    config['SURFACE_FLUX_SCHEME'] = case.get_value('SURFACE_FLUX_SCHEME')
 #-tht
     config['CPL_EPBAL'] = case.get_value('CPL_EPBAL')
     config['FLDS_WISO'] = case.get_value('FLDS_WISO')
@@ -77,6 +78,8 @@ def _create_drv_namelists(case, infile, confdir, nmlgen, files):
 #+tht setting alb_cosz_avg values
     ALB_COSZ_AVG_NORESM = case.get_value('COSZ_AVG')
     nmlgen.set_value('alb_cosz_avg', value=ALB_COSZ_AVG_NORESM)
+    OCN_SURFACE_FLUX_SCHEME_NORESM = case.get_value('SURFACE_FLUX_SCHEME')
+    nmlgen.set_value('ocn_surface_flux_scheme', value=OCN_SURFACE_FLUX_SCHEME_NORESM)
 #-tht
 
     #--------------------------------

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -487,6 +487,27 @@
     </desc>
   </entry>
 
+  <entry id="SURFACE_FLUX_SCHEME">
+    <type>char</type>
+    <valid_values>0,1,2</valid_values>
+    <default_value>0</default_value>
+    <values match="last">
+      <value compset="_CAM5%PTAEROUPD1">1</value>
+      <value compset="_CAM60%PTAERO">1</value>
+      <value compset="_CAM60%NORESM">1</value>
+      <value compset="_CAM54%PTAERO">1</value>
+      <value compset="_CAM5%NUDGEPTAEROUPD1">1</value>
+      <value compset="_CAM54%NUDGEPTAERO">1</value>
+      <value compset="_CAM60%NUDGEPTAERO">1</value>
+      <value compset="_BLOM">1</value>
+    </values>
+    <group>run_component_cpl</group>
+    <file>env_run.xml</file>
+    <desc>
+      Default is 0 and 1 for N* compsets, controls value of OCN_SURFACE_FLUX_SCHEME
+    </desc>
+  </entry>
+
   <entry id="CPL_EPBAL">
     <type>char</type>
     <valid_values>off,ocn</valid_values>

--- a/src/drivers/mct/cime_config/namelist_definition_drv.xml
+++ b/src/drivers/mct/cime_config/namelist_definition_drv.xml
@@ -754,7 +754,8 @@
       default: 0
      </desc>
      <values>
-      <value>0</value>
+      <!--value>0</value-->
+      <value>$SURFACE_FLUX_SCHEME</value>
      </values>
   </entry>
 


### PR DESCRIPTION
Introduced modification to have for NorESM compsets by default ocn_surface_flux_scheme=1 (COARE flux) instead of 0 (standard for CESM compsets) in NorESM2.2.

In the upgraded CESM2.2 version which is the basis for NorESM2.2, ocn_surface_flux_scheme has been introduced, but its default value is 0.  By this modification, the value will be 1 for NorESM compsets.

The results are equal (bit-identical) to putting in user_nl_cpl : ocn_surface_flux_scheme = 1

Modified files : 
src/drivers/mct/cime_config/buildnml
src/drivers/mct/cime_config/config_component_cesm.xml
src/drivers/mct/cime_config/namelist_definition_drv.xml

Test suite: N1850_f19_tn14_20211104_test22
Test baseline: N1850_f19_tn14_20211104_test16
Test namelist changes: 
Test status: bit for bit

Fixes [CIME Github issue #]

User interface changes?: 

Update gh-pages html (Y/N)?:

Code review: 
