### PR TITLE
removed reference to config_grids_mct.xml from cesm config_files.xml

### DIFF
--- a/CIME/data/config/cesm/config_files.xml
+++ b/CIME/data/config/cesm/config_files.xml
@@ -29,7 +29,6 @@
     <default_value>$SRCROOT/ccs_config/config_grids.xml</default_value>
     <values>
       <value comp_interface="nuopc">$SRCROOT/ccs_config/config_grids_nuopc.xml</value>
-      <value comp_interface="mct">$SRCROOT/ccs_config/config_grids_mct.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>


### PR DESCRIPTION
This is a CESM/NorESM specific change and should not effect the rest of the code.
This is needed to work with the latest ccs_config version in NorESM where all mct xml grid specifications have been removed.

Test status: bit for bit

Fixes:None

User interface changes?: None

Update gh-pages html (Y/N)?: N
