### PR TITLE
updates for grids and machines, including removal of deprecated machines

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -341,7 +341,7 @@
       <grid name="lnd">T62</grid>
       <grid name="ocnice">tnx0.25v4</grid>
     </model_grid>
-    
+
     <model_grid alias="T62_tn01254" not_compset="_CAM">
       <grid name="atm">T62</grid>
       <grid name="lnd">T62</grid>
@@ -465,31 +465,31 @@
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
-      <mask>null</mask>
+      <mask>tnx1v4</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_mnull" compset="_DOCN%SAQUAP|DOCN%DAQUAP" >
+    <model_grid alias="f09_f09_mtn14" compset="_DOCN" >
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
-      <mask>null</mask>
+      <mask>tnx1v4</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_mg16" not_compset="_POP" >
+    <model_grid alias="f09_f09_mg16" compset="_DOCN" >
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_mg17" not_compset="_POP" >
+    <model_grid alias="f09_f09_mg17" compset="_DOCN" >
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="f05_f05_mg17" not_compset="_POP" >
+    <model_grid alias="f05_f05_mg17" compset="_DOCN" >
       <grid name="atm">0.47x0.63</grid>
       <grid name="lnd">0.47x0.63</grid>
       <grid name="ocnice">0.47x0.63</grid>
@@ -606,25 +606,25 @@
       <mask>gx1v7</mask>
     </model_grid>
 
+    <model_grid alias="f19_f19" not_compset="_POP">
+      <grid name="atm">1.9x2.5</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">1.9x2.5</grid>
+      <mask>tnx1v4</mask>
+    </model_grid>
+
+    <model_grid alias="f19_f19_mtn14" not_compset="_POP">
+      <grid name="atm">1.9x2.5</grid>
+      <grid name="lnd">1.9x2.5</grid>
+      <grid name="ocnice">1.9x2.5</grid>
+      <mask>tnx1v4</mask>
+    </model_grid>
+
     <model_grid alias="f19_f19_mg16" not_compset="_POP">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
       <mask>gx1v6</mask>
-    </model_grid>
-
-    <model_grid alias="f19_f19" not_compset="_POP">
-      <grid name="atm">1.9x2.5</grid>
-      <grid name="lnd">1.9x2.5</grid>
-      <grid name="ocnice">1.9x2.5</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
-    <model_grid alias="f19_f19_mnull" compset="_DOCN%SAQUAP|DOCN%DAQUAP" >
-      <grid name="atm">1.9x2.5</grid>
-      <grid name="lnd">1.9x2.5</grid>
-      <grid name="ocnice">1.9x2.5</grid>
-      <mask>null</mask>
     </model_grid>
 
     <model_grid alias="f19_f19_mg17" not_compset="_POP">
@@ -740,7 +740,7 @@
       <grid name="ocnice">tnx0.25v4</grid>
       <mask>tnx0.25v4</mask>
     </model_grid>
-    
+
     <model_grid alias="f09_tn01254" not_compset="_POP">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
@@ -1216,7 +1216,7 @@
       <file grid="atm|lnd" mask="gx1v6">domain.lnd.fv0.23x0.31_gx1v6.100517.nc</file>
       <file grid="ocnice"  mask="gx1v6">domain.ocn.0.23x0.31_gx1v6_101108.nc</file>
       <file grid="atm|lnd" mask="tnx0.25v4">domain.lnd.fv0.23x0.31_tnx0.25v4.191031.nc</file>
-      <file grid="ocnice"  mask="tnx0.25v4">domain.ocn.tnx0.25v4.191031.nc</file>
+      <file grid="atm|lnd" mask="tnx0.25v4"></file>
       <desc>0.23x0.31 is FV 1/4-deg grid:</desc>
     </domain>
 
@@ -1233,26 +1233,27 @@
       <nx>288</nx>  <ny>192</ny>
       <file grid="atm|lnd" mask="gx1v6">domain.lnd.fv0.9x1.25_gx1v6.090309.nc</file>
       <file grid="ocnice"  mask="gx1v6">domain.ocn.0.9x1.25_gx1v6_090403.nc</file>
+
       <file grid="atm|lnd" mask="gx1v7">domain.lnd.fv0.9x1.25_gx1v7.151020.nc</file>
       <file grid="ocnice"  mask="gx1v7">domain.ocn.fv0.9x1.25_gx1v7.151020.nc</file>
-<!--  <file grid="atm|lnd" mask="null">/glade/u/home/benedict/ys/datain/domain.aqua.fv0.9x1.25.nc</file>
-      <file grid="ocnice"  mask="null">/glade/u/home/benedict/ys/datain/domain.aqua.fv0.9x1.25.nc</file> -->
-      <file grid="atm|lnd" mask="null">domain.aqua.fv0.9x1.25.nc</file>
-      <file grid="ocnice"  mask="null">domain.aqua.fv0.9x1.25.nc</file>
+
       <file grid="atm|lnd" mask="tnx1v1">domain.lnd.fv0.9x1.25_tnx1v1.150512.nc</file>
       <file grid="ocnice"  mask="tnx1v1">domain.ocn.0.9x1.25_tnx1v1.150512.nc</file>
-      <file grid="atm|lnd" mask="tnx1v3">domain.lnd.fv0.9x1.25_tnx1v3.170621.nc</file>
-      <file grid="ocnice"  mask="tnx1v3">domain.ocn.tnx1v3.170621.nc</file>
+
       <file grid="atm|lnd" mask="tnx1v4">domain.lnd.fv0.9x1.25_tnx1v4.170609.nc</file>
-      <file grid="ocnice"  mask="tnx1v4">domain.ocn.tnx1v4.170606.nc</file>
+      <file grid="ocnice"  mask="tnx1v4">domain.ocn.fv0.9x1.25_tnx1v4.170609_djlo.nc</file>
+
       <file grid="atm|lnd" mask="tnx0.25v1">domain.lnd.fv0.9x1.25_tnx0.25v1.140618.nc</file>
+      <file grid="ocnice"  mask="tnx0.25v1">domain.ocn.0.9x1.25_tnx0.25v1.140618.nc</file>
+
       <file grid="atm|lnd" mask="tnx0.25v3">domain.lnd.fv0.9x1.25_tnx0.25v3.170629.nc</file>
-      <file grid="ocnice"  mask="tnx0.25v3">domain.ocn.tnx0.25v3.170629.nc</file>
-      <file grid="atm|lnd" mask="tnx0.25v4">domain.lnd.fv0.9x1.25_tnx0.25v4.170629.nc</file>
-      <file grid="ocnice"  mask="tnx0.25v4">domain.ocn.tnx0.25v4.170629.nc</file>
-      <file grid="atm|lnd" mask="tnx0.125v4">domain.lnd.fv0.9x1.25_tnx0.125v4.200830.nc</file>
-      <file grid="ocnice"  mask="tnx0.125v4">domain.ocn.tnx0.125v4.200725.nc</file>
-      <!--file grid="ocnice" mask="tnx0.25v1">domain.ocn.0.9x1.25_tnx0.25v1.140618.nc</file-->
+      <file grid="ocnice"  mask="tnx0.25v3"></file>
+
+      <!-- <file grid="atm|lnd" mask="tnx0.25v4">domain.lnd.fv0.9x1.25_tnx0.25v4.170629.nc</file> -->
+      <!-- <file grid="ocnice"  mask="tnx0.25v4"></file> -->
+
+      <!-- <file grid="atm|lnd" mask="tnx0.125v4">domain.lnd.fv0.9x1.25_tnx0.125v4.200830.nc</file> -->
+      <!-- <file grid="ocnice"  mask="tnx0.1.25v4"></file> -->
       <desc>0.9x1.25 is FV 1-deg grid:</desc>
     </domain>
 
@@ -1260,14 +1261,12 @@
       <nx>144</nx>  <ny>96</ny>
       <file grid="atm|lnd" mask="gx1v6">domain.lnd.fv1.9x2.5_gx1v6.090206.nc</file>
       <file grid="ocnice"  mask="gx1v6">domain.ocn.1.9x2.5_gx1v6_090403.nc</file>
+
       <file grid="atm|lnd" mask="gx1v7">domain.lnd.fv1.9x2.5_gx1v7.170518.nc</file>
       <file grid="ocnice"  mask="gx1v7">domain.ocn.fv1.9x2.5_gx1v7.170518.nc</file>
-      <file grid="ocnice"  mask="null">domain.aqua.fv1.9x2.5.nc</file>
-      <file grid="atm|lnd" mask="tnx1v1">domain.lnd.fv1.9x2.5_tnx1v1.120120.nc</file>
-      <file grid="atm|lnd" mask="tnx1v3">domain.lnd.fv1.9x2.5_tnx1v3.170622.nc</file>
-      <file grid="ocnice"  mask="tnx1v3">domain.ocn.tnx1v3.170622.nc</file>
+
       <file grid="atm|lnd" mask="tnx1v4">domain.lnd.fv1.9x2.5_tnx1v4.170609.nc</file>
-      <file grid="ocnice"  mask="tnx1v4">domain.ocn.tnx1v4.170606.nc</file>
+      <file grid="ocnice"  mask="tnx1v4">domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</file>
       <desc>1.9x2.5 is FV 2-deg grid:</desc>
     </domain>
 
@@ -1315,24 +1314,24 @@
 
     <domain name="T62">
       <nx>192</nx>  <ny>96</ny>
-      <file grid="atm|lnd" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx1v7.151008.nc</file>
-      <file grid="atm|lnd" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx1v6.090320.nc</file>
-      <file grid="atm|lnd" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx3v7.090911.nc</file>
-      <file grid="atm|lnd" mask="tx1v1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tx1v1.090122.nc</file>
-      <file grid="atm|lnd" mask="tx0.1v2">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tx0.1v2_090623.nc</file>
-      <file grid="atm|lnd" mask="tx0.1v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tx0.1v3.170929.nc</file>
-      <file grid="atm|lnd" mask="oQU120">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU120.160325.nc</file>
-      <file grid="ocnice" mask="gx1v6">$DIN_LOC_ROOT/share/domains/domain.ocn.T62_gx1v6.130409.nc</file>
-      <file grid="ocnice" mask="gx1v7">$DIN_LOC_ROOT/share/domains/domain.ocn.T62_gx1v7.151008.nc</file>
-      <file grid="ocnice" mask="gx3v7">$DIN_LOC_ROOT/share/domains/domain.ocn.T62_gx3v7.130409.nc</file>
-      <file grid="atm|lnd" mask="tnx2v1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx2v1.130206.nc</file>
-      <file grid="atm|lnd" mask="tnx1v1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx1v1.120120.nc</file>
-      <file grid="atm|lnd" mask="tnx1v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx1v3.170621.nc</file>
-      <file grid="atm|lnd" mask="tnx1v4">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx1v4.170606.nc</file>
-      <file grid="atm|lnd" mask="tnx0.25v1">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx0.25v1.130930.nc</file>
-      <file grid="atm|lnd" mask="tnx0.25v3">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx0.25v3.170629.nc</file>
-      <file grid="atm|lnd" mask="tnx0.25v4">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx0.25v4.170629.nc</file>
-      <file grid="atm|lnd" mask="tnx0.125v4">$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx0.125v4.200725.nc</file>
+      <file grid="atm|lnd" mask="gx1v7"      >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx1v7.151008.nc</file>
+      <file grid="atm|lnd" mask="gx1v6"      >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx1v6.090320.nc</file>
+      <file grid="atm|lnd" mask="gx3v7"      >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_gx3v7.090911.nc</file>
+      <file grid="atm|lnd" mask="tx1v1"      >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tx1v1.090122.nc</file>
+      <file grid="atm|lnd" mask="tx0.1v2"    >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tx0.1v2_090623.nc</file>
+      <file grid="atm|lnd" mask="tx0.1v3"    >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tx0.1v3.170929.nc</file>
+      <file grid="atm|lnd" mask="oQU120"     >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_oQU120.160325.nc</file>
+      <file grid="ocnice"  mask="gx1v6"      >$DIN_LOC_ROOT/share/domains/domain.ocn.T62_gx1v6.130409.nc</file>
+      <file grid="ocnice"  mask="gx1v7"      >$DIN_LOC_ROOT/share/domains/domain.ocn.T62_gx1v7.151008.nc</file>
+      <file grid="ocnice"  mask="gx3v7"      >$DIN_LOC_ROOT/share/domains/domain.ocn.T62_gx3v7.130409.nc</file>
+      <file grid="atm|lnd" mask="tnx2v1"     >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx2v1.130206.nc</file>
+      <file grid="atm|lnd" mask="tnx1v1"     >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx1v1.120120.nc</file>
+      <file grid="atm|lnd" mask="tnx1v3"     >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx1v3.170621.nc</file>
+      <file grid="atm|lnd" mask="tnx1v4"     >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx1v4.170606.nc</file>
+      <file grid="atm|lnd" mask="tnx0.25v1"  >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx0.25v1.130930.nc</file>
+      <file grid="atm|lnd" mask="tnx0.25v3"  >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx0.25v3.170629.nc</file>
+      <file grid="atm|lnd" mask="tnx0.25v4"  >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx0.25v4.170629.nc</file>
+      <file grid="atm|lnd" mask="tnx0.125v4" >$DIN_LOC_ROOT/share/domains/domain.lnd.T62_tnx0.125v4.200725.nc</file>
       <desc>T62 is Gaussian grid:</desc>
     </domain>
 
@@ -1622,7 +1621,7 @@
       <file grid="ocnice">$DIN_LOC_ROOT/share/domains/domain.ocn.tnx0.125v4.200725.nc</file>
       <desc>tripole v4 1/8-deg grid</desc>
       <support>tripole ocean grid</support>
-    </domain>    
+    </domain>
 
     <domain name="rx1">
       <nx>360</nx> <ny>180</ny>
@@ -2440,7 +2439,7 @@
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="tnx0.25v1" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tnx0.25v1_e300r100_130930.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_tnx0.25v1_e300r100_130930.nc</map>   
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_rx1_to_tnx0.25v1_e300r100_130930.nc</map>
     </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="tnx0.25v3" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_rx1_to_tnx0.25v3_e300r100_170629.nc</map>

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1246,6 +1246,8 @@
       <file grid="atm|lnd" mask="tnx0.25v1">domain.lnd.fv0.9x1.25_tnx0.25v1.140618.nc</file>
       <file grid="ocnice"  mask="tnx0.25v1">domain.ocn.0.9x1.25_tnx0.25v1.140618.nc</file>
 
+      <!-- NOTE: the following do not have valid domain files for ocn/ice and so are commented out -->
+
       <!-- <file grid="atm|lnd" mask="tnx0.25v3">domain.lnd.fv0.9x1.25_tnx0.25v3.170629.nc</file> -->
       <!-- <file grid="ocnice"  mask="tnx0.25v3"></file> -->
 

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -158,49 +158,49 @@
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="T42_T42_musgs" not_compset="_POP">
+    <model_grid alias="T42_T42_musgs" not_compset="_POP|_BLOM">
       <grid name="atm">T42</grid>
       <grid name="lnd">T42</grid>
       <grid name="ocnice">T42</grid>
       <mask>usgs</mask>
     </model_grid>
 
-    <model_grid alias="T42_T42" not_compset="_POP">
+    <model_grid alias="T42_T42" not_compset="_POP|_BLOM">
       <grid name="atm">T42</grid>
       <grid name="lnd">T42</grid>
       <grid name="ocnice">T42</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="T42_T42_mg16" not_compset="_POP">
+    <model_grid alias="T42_T42_mg16" not_compset="_POP|_BLOM">
       <grid name="atm">T42</grid>
       <grid name="lnd">T42</grid>
       <grid name="ocnice">T42</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="T42_T42_mg17" not_compset="_POP">
+    <model_grid alias="T42_T42_mg17" not_compset="_POP|_BLOM">
       <grid name="atm">T42</grid>
       <grid name="lnd">T42</grid>
       <grid name="ocnice">T42</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="T85_T85_mg16" not_compset="_POP">
+    <model_grid alias="T85_T85_mg16" not_compset="_POP|_BLOM">
       <grid name="atm">T85</grid>
       <grid name="lnd">T85</grid>
       <grid name="ocnice">T85</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="T85_T85_mg17" not_compset="_POP">
+    <model_grid alias="T85_T85_mg17" not_compset="_POP|_BLOM">
       <grid name="atm">T85</grid>
       <grid name="lnd">T85</grid>
       <grid name="ocnice">T85</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="T85_T85_musgs" not_compset="_POP">
+    <model_grid alias="T85_T85_musgs" not_compset="_POP|_BLOM">
       <grid name="atm">T85</grid>
       <grid name="lnd">T85</grid>
       <grid name="ocnice">T85</grid>
@@ -496,7 +496,7 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_gl5" compset="_CISM" not_compset="_POP">
+    <model_grid alias="f09_f09_gl5" compset="_CISM" not_compset="_POP|_BLOM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
@@ -504,7 +504,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_gl5_mg16" compset="_CISM" not_compset="_POP">
+    <model_grid alias="f09_f09_gl5_mg16" compset="_CISM" not_compset="_POP|_BLOM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
@@ -512,7 +512,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_gl5_mg17" compset="_CISM" not_compset="_POP">
+    <model_grid alias="f09_f09_gl5_mg17" compset="_CISM" not_compset="_POP|_BLOM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
@@ -582,7 +582,7 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_gl5" compset="_CISM" not_compset="_POP">
+    <model_grid alias="f19_f19_gl5" compset="_CISM" not_compset="_POP|_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
@@ -590,7 +590,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_gl5_mg16" compset="_CISM" not_compset="_POP">
+    <model_grid alias="f19_f19_gl5_mg16" compset="_CISM" not_compset="_POP|_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
@@ -598,7 +598,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_gl5_mg17" compset="_CISM" not_compset="_POP">
+    <model_grid alias="f19_f19_gl5_mg17" compset="_CISM" not_compset="_POP|_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
@@ -606,28 +606,28 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19" not_compset="_POP">
+    <model_grid alias="f19_f19" not_compset="_POP|_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
       <mask>tnx1v4</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_mtn14" not_compset="_POP">
+    <model_grid alias="f19_f19_mtn14" not_compset="_POP|_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
       <mask>tnx1v4</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_mg16" not_compset="_POP">
+    <model_grid alias="f19_f19_mg16" not_compset="_POP|_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_mg17" not_compset="_POP">
+    <model_grid alias="f19_f19_mg17" not_compset="_POP|_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
@@ -641,49 +641,49 @@
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="f02_f02_mg16" not_compset="_POP">
+    <model_grid alias="f02_f02_mg16" not_compset="_POP|_BLOM">
       <grid name="atm">0.23x0.31</grid>
       <grid name="lnd">0.23x0.31</grid>
       <grid name="ocnice">0.23x0.31</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f02_f02_mg17" not_compset="_POP">
+    <model_grid alias="f02_f02_mg17" not_compset="_POP|_BLOM">
       <grid name="atm">0.23x0.31</grid>
       <grid name="lnd">0.23x0.31</grid>
       <grid name="ocnice">0.23x0.31</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="f25_f25_mg16" not_compset="_POP">
+    <model_grid alias="f25_f25_mg16" not_compset="_POP|_BLOM">
       <grid name="atm">2.5x3.33</grid>
       <grid name="lnd">2.5x3.33</grid>
       <grid name="ocnice">2.5x3.33</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f25_f25_mg17" not_compset="_POP">
+    <model_grid alias="f25_f25_mg17" not_compset="_POP|_BLOM">
       <grid name="atm">2.5x3.33</grid>
       <grid name="lnd">2.5x3.33</grid>
       <grid name="ocnice">2.5x3.33</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="f45_f45_mg37" not_compset="_POP">
+    <model_grid alias="f45_f45_mg37" not_compset="_POP|_BLOM">
       <grid name="atm">4x5</grid>
       <grid name="lnd">4x5</grid>
       <grid name="ocnice">4x5</grid>
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="f10_f10_mg37" not_compset="_POP">
+    <model_grid alias="f10_f10_mg37" not_compset="_POP|_BLOM">
       <grid name="atm">10x15</grid>
       <grid name="lnd">10x15</grid>
       <grid name="ocnice">10x15</grid>
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="f10_f10_musgs" not_compset="_POP">
+    <model_grid alias="f10_f10_musgs" not_compset="_POP|_BLOM">
       <grid name="atm">10x15</grid>
       <grid name="lnd">10x15</grid>
       <grid name="ocnice">10x15</grid>
@@ -769,13 +769,13 @@
       <mask>tnx1v4</mask>
     </model_grid>
 
-    <model_grid alias="f19_g16" not_compset="_POP">
+    <model_grid alias="f19_g16" not_compset="_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">gx1v6</grid>
     </model_grid>
 
-    <model_grid alias="f19_g16_gl4" not_compset="_POP">
+    <model_grid alias="f19_g16_gl4" not_compset="_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">gx1v6</grid>
@@ -800,42 +800,42 @@
     </model_grid>
     <!--  spectral element grids -->
 
-    <model_grid alias="ne5_ne5_mg37" not_compset="_POP">
+    <model_grid alias="ne5_ne5_mg37" not_compset="_POP|_BLOM">
       <grid name="atm">ne5np4</grid>
       <grid name="lnd">ne5np4</grid>
       <grid name="ocnice">ne5np4</grid>
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="ne16_g17">
+    <model_grid alias="ne16_g17" not_compset="_BLOM">
       <grid name="atm">ne16np4</grid>
       <grid name="lnd">ne16np4</grid>
       <grid name="ocnice">gx1v7</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne16_ne16_mg17" not_compset="_POP">
+    <model_grid alias="ne16_ne16_mg17" not_compset="_POP|_BLOM">
       <grid name="atm">ne16np4</grid>
       <grid name="lnd">ne16np4</grid>
       <grid name="ocnice">ne16np4</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne30_g16">
+    <model_grid alias="ne30_g16" not_compset="_BLOM">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">ne30np4</grid>
       <grid name="ocnice">gx1v6</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne30_g17">
+    <model_grid alias="ne30_g17" not_compset="_BLOM">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">ne30np4</grid>
       <grid name="ocnice">gx1v7</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne30_f19_g16">
+    <model_grid alias="ne30_f19_g16" not_compset="_BLOM">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">gx1v6</grid>
@@ -843,7 +843,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne30_f19_g17">
+    <model_grid alias="ne30_f19_g17" not_compset="_BLOM">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -851,7 +851,7 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne30_f09_g16">
+    <model_grid alias="ne30_f09_g16" not_compset="_BLOM">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">gx1v6</grid>
@@ -859,7 +859,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne30_f09_g17">
+    <model_grid alias="ne30_f09_g17" not_compset="_BLOM">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -867,70 +867,70 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne30_ne30_mg16" not_compset="_POP">
+    <model_grid alias="ne30_ne30_mg16" not_compset="_POP|_BLOM">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">ne30np4</grid>
       <grid name="ocnice">ne30np4</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne30_ne30_mg17" not_compset="_POP">
+    <model_grid alias="ne30_ne30_mg17" not_compset="_POP|_BLOM">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">ne30np4</grid>
       <grid name="ocnice">ne30np4</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne60_g16">
+    <model_grid alias="ne60_g16" not_compset="_BLOM">
       <grid name="atm">ne60np4</grid>
       <grid name="lnd">ne60np4</grid>
       <grid name="ocnice">gx1v6</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne60_g17">
+    <model_grid alias="ne60_g17" not_compset="_BLOM">
       <grid name="atm">ne60np4</grid>
       <grid name="lnd">ne60np4</grid>
       <grid name="ocnice">gx1v7</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne60_ne60_mg16" not_compset="_POP">
+    <model_grid alias="ne60_ne60_mg16" not_compset="_POP|_BLOM">
       <grid name="atm">ne60np4</grid>
       <grid name="lnd">ne60np4</grid>
       <grid name="ocnice">ne60np4</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne120_g16">
+    <model_grid alias="ne120_g16" not_compset="_BLOM">
       <grid name="atm">ne120np4</grid>
       <grid name="lnd">ne120np4</grid>
       <grid name="ocnice">gx1v6</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne120_g17">
+    <model_grid alias="ne120_g17" not_compset="_BLOM">
       <grid name="atm">ne120np4</grid>
       <grid name="lnd">ne120np4</grid>
       <grid name="ocnice">gx1v7</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne120_t12">
+    <model_grid alias="ne120_t12" not_compset="_BLOM">
       <grid name="atm">ne120np4</grid>
       <grid name="lnd">ne120np4</grid>
       <grid name="ocnice">tx0.1v2</grid>
       <mask>tx0.1v2</mask>
     </model_grid>
 
-    <model_grid alias="ne120_ne120_mg16" not_compset="_POP">
+    <model_grid alias="ne120_ne120_mg16" not_compset="_POP|_BLOM">
       <grid name="atm">ne120np4</grid>
       <grid name="lnd">ne120np4</grid>
       <grid name="ocnice">ne120np4</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne240_f02_g16">
+    <model_grid alias="ne240_f02_g16" not_compset="_BLOM">
       <grid name="atm">ne240np4</grid>
       <grid name="lnd">0.23x0.31</grid>
       <grid name="ocnice">gx1v6</grid>
@@ -938,7 +938,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne240_f02_g17">
+    <model_grid alias="ne240_f02_g17" not_compset="_BLOM">
       <grid name="atm">ne240np4</grid>
       <grid name="lnd">0.23x0.31</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -946,21 +946,21 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne240_t12">
+    <model_grid alias="ne240_t12" not_compset="_BLOM">
       <grid name="atm">ne240np4</grid>
       <grid name="lnd">ne240np4</grid>
       <grid name="ocnice">tx0.1v2</grid>
       <mask>tx0.1v2</mask>
     </model_grid>
 
-    <model_grid alias="ne240_ne240_mg16" not_compset="_POP">
+    <model_grid alias="ne240_ne240_mg16" not_compset="_POP|_BLOM">
       <grid name="atm">ne240np4</grid>
       <grid name="lnd">ne240np4</grid>
       <grid name="ocnice">ne240np4</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne240_ne240_mg17" not_compset="_POP">
+    <model_grid alias="ne240_ne240_mg17" not_compset="_POP|_BLOM">
       <grid name="atm">ne240np4</grid>
       <grid name="lnd">ne240np4</grid>
       <grid name="ocnice">ne240np4</grid>
@@ -969,28 +969,28 @@
 
     <!--  spectral element grids with 2x2 FVM physics grid -->
 
-    <model_grid alias="ne30pg2_ne30pg2_mg17" not_compset="_POP|_CLM">
+    <model_grid alias="ne30pg2_ne30pg2_mg17" not_compset="_POP|_BLOM|_CLM">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">ne30np4.pg2</grid>
       <grid name="ocnice">ne30np4.pg2</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne60pg2_ne60pg2_mg17" not_compset="_POP|_CLM">
+    <model_grid alias="ne60pg2_ne60pg2_mg17" not_compset="_POP|_BLOM|_CLM">
       <grid name="atm">ne60np4.pg2</grid>
       <grid name="lnd">ne60np4.pg2</grid>
       <grid name="ocnice">ne60np4.pg2</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne120pg2_ne120pg2_mg17" not_compset="_POP|_CLM">
+    <model_grid alias="ne120pg2_ne120pg2_mg17" not_compset="_POP|_BLOM|_CLM">
       <grid name="atm">ne120np4.pg2</grid>
       <grid name="lnd">ne120np4.pg2</grid>
       <grid name="ocnice">ne120np4.pg2</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne240pg2_ne240pg2_mg17" not_compset="_POP|_CLM">
+    <model_grid alias="ne240pg2_ne240pg2_mg17" not_compset="_POP|_BLOM|_CLM">
       <grid name="atm">ne240np4.pg2</grid>
       <grid name="lnd">ne240np4.pg2</grid>
       <grid name="ocnice">ne240np4.pg2</grid>
@@ -999,42 +999,42 @@
 
     <!--  spectral element grids with 3x3 FVM physics grid -->
 
-    <model_grid alias="ne5pg3_ne5pg3_mg37" not_compset="_POP">
+    <model_grid alias="ne5pg3_ne5pg3_mg37" not_compset="_POP|_BLOM">
       <grid name="atm">ne5np4.pg3</grid>
       <grid name="lnd">ne5np4.pg3</grid>
       <grid name="ocnice">ne5np4.pg3</grid>
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="ne16pg3_ne16pg3_mg37" not_compset="_POP|_CLM">
+    <model_grid alias="ne16pg3_ne16pg3_mg37" not_compset="_POP|_BLOM|_CLM">
       <grid name="atm">ne16np4.pg3</grid>
       <grid name="lnd">ne16np4.pg3</grid>
       <grid name="ocnice">ne16np4.pg3</grid>
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="ne30pg3_ne30pg3_mg17" not_compset="_POP|_CLM">
+    <model_grid alias="ne30pg3_ne30pg3_mg17" not_compset="_POP|_BLOM|_CLM">
       <grid name="atm">ne30np4.pg3</grid>
       <grid name="lnd">ne30np4.pg3</grid>
       <grid name="ocnice">ne30np4.pg3</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne60pg3_ne60pg3_mg17" not_compset="_POP|_CLM">
+    <model_grid alias="ne60pg3_ne60pg3_mg17" not_compset="_POP|_BLOM|_CLM">
       <grid name="atm">ne60np4.pg3</grid>
       <grid name="lnd">ne60np4.pg3</grid>
       <grid name="ocnice">ne60np4.pg3</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne120pg3_ne120pg3_mg17" not_compset="_POP|_CLM">
+    <model_grid alias="ne120pg3_ne120pg3_mg17" not_compset="_POP|_BLOM|_CLM">
       <grid name="atm">ne120np4.pg3</grid>
       <grid name="lnd">ne120np4.pg3</grid>
       <grid name="ocnice">ne120np4.pg3</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne240pg3_ne240pg3_mg17" not_compset="_POP|_CLM">
+    <model_grid alias="ne240pg3_ne240pg3_mg17" not_compset="_POP|_BLOM|_CLM">
       <grid name="atm">ne240np4.pg3</grid>
       <grid name="lnd">ne240np4.pg3</grid>
       <grid name="ocnice">ne240np4.pg3</grid>
@@ -1043,21 +1043,21 @@
 
     <!--  spectral element grids with 4x4 FVM physics grid -->
 
-    <model_grid alias="ne30pg4_ne30pg4_mg17" not_compset="_POP|_CLM">
+    <model_grid alias="ne30pg4_ne30pg4_mg17" not_compset="_POP|_BLOM|_CLM">
       <grid name="atm">ne30np4.pg4</grid>
       <grid name="lnd">ne30np4.pg4</grid>
       <grid name="ocnice">ne30np4.pg4</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne60pg4_ne60pg4_mg17" not_compset="_POP|_CLM">
+    <model_grid alias="ne60pg4_ne60pg4_mg17" not_compset="_POP|_BLOM|_CLM">
       <grid name="atm">ne60np4.pg4</grid>
       <grid name="lnd">ne60np4.pg4</grid>
       <grid name="ocnice">ne60np4.pg4</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne120pg4_ne120pg4_mg17" not_compset="_POP|_CLM">
+    <model_grid alias="ne120pg4_ne120pg4_mg17" not_compset="_POP|_BLOM|_CLM">
       <grid name="atm">ne120np4.pg4</grid>
       <grid name="lnd">ne120np4.pg4</grid>
       <grid name="ocnice">ne120np4.pg4</grid>
@@ -1066,14 +1066,14 @@
 
    <!-- VR-CESM grids with CAM-SE -->
 
-    <model_grid alias="ne0TESTONLYne5x4_ne0TESTONLYne5x4_mg37" not_compset="_POP">
+    <model_grid alias="ne0TESTONLYne5x4_ne0TESTONLYne5x4_mg37" not_compset="_POP|_BLOM">
       <grid name="atm">ne0np4TESTONLY.ne5x4</grid>
       <grid name="lnd">ne0np4TESTONLY.ne5x4</grid>
       <grid name="ocnice">ne0np4TESTONLY.ne5x4</grid>
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="ne0CONUSne30x8_ne0CONUSne30x8_mt12" not_compset="_POP">
+    <model_grid alias="ne0CONUSne30x8_ne0CONUSne30x8_mt12" not_compset="_POP|_BLOM">
       <grid name="atm">ne0np4CONUS.ne30x8</grid>
       <grid name="lnd">ne0np4CONUS.ne30x8</grid>
       <grid name="ocnice">ne0np4CONUS.ne30x8</grid>
@@ -1704,7 +1704,6 @@
     <required_gridmap grid1="atm_grid" grid2="wav_grid">ATM2WAV_SMAPNAME</required_gridmap>
     <required_gridmap grid1="ocn_grid" grid2="wav_grid">OCN2WAV_SMAPNAME</required_gridmap>
     <required_gridmap grid1="ocn_grid" grid2="wav_grid">ICE2WAV_SMAPNAME</required_gridmap> <!-- ??? -->
-    <!-- <required_gridmap grid1="ocn_grid" grid2="rof_grid" not_compset="_POP">ROF2OCN_FMAPNAME</required_gridmap> ?? -->
     <required_gridmap grid1="ocn_grid" grid2="rof_grid" >ROF2OCN_LIQ_RMAPNAME</required_gridmap>
     <required_gridmap grid1="ocn_grid" grid2="rof_grid" >ROF2OCN_ICE_RMAPNAME</required_gridmap>
     <required_gridmap grid1="lnd_grid" grid2="rof_grid">LND2ROF_FMAPNAME</required_gridmap>

--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -1246,8 +1246,8 @@
       <file grid="atm|lnd" mask="tnx0.25v1">domain.lnd.fv0.9x1.25_tnx0.25v1.140618.nc</file>
       <file grid="ocnice"  mask="tnx0.25v1">domain.ocn.0.9x1.25_tnx0.25v1.140618.nc</file>
 
-      <file grid="atm|lnd" mask="tnx0.25v3">domain.lnd.fv0.9x1.25_tnx0.25v3.170629.nc</file>
-      <file grid="ocnice"  mask="tnx0.25v3"></file>
+      <!-- <file grid="atm|lnd" mask="tnx0.25v3">domain.lnd.fv0.9x1.25_tnx0.25v3.170629.nc</file> -->
+      <!-- <file grid="ocnice"  mask="tnx0.25v3"></file> -->
 
       <!-- <file grid="atm|lnd" mask="tnx0.25v4">domain.lnd.fv0.9x1.25_tnx0.25v4.170629.nc</file> -->
       <!-- <file grid="ocnice"  mask="tnx0.25v4"></file> -->

--- a/config/cesm/machines/config_batch.xml
+++ b/config/cesm/machines/config_batch.xml
@@ -548,7 +548,7 @@
    <!-- vilje is PBS -->
   <batch_system MACH="vilje" type="pbs">
     <submit_args>
-      <arg flag="-N cesmRun"/> 
+      <arg flag="-N cesmRun"/>
     </submit_args>
     <directives>
       <directive>-A nn2345k</directive>
@@ -599,7 +599,7 @@
     </directives>
     <directives queue = "preproc">
       <directive> --partition=preproc</directive>
-      <directive> --mem-per-cpu=64G</directive>
+      <directive> --mem-per-cpu=16G</directive>
     </directives>
     <queues>
       <queue walltimemax="00:59:00" nodemin="4" nodemax="1024" default="true">normal</queue>

--- a/src/components/data_comps/docn/cime_config/config_component.xml
+++ b/src/components/data_comps/docn/cime_config/config_component.xml
@@ -150,27 +150,57 @@
     <valid_values></valid_values>
     <default_value>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_c101029.nc</default_value>
     <values match="last">
-      <value compset="DOCN%DOM" grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_clim_c050526.nc</value>
-      <value compset="DOCN%DOM" grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_clim_c061031.nc</value>
-      <value compset="DOCN%DOM" grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
-      <value compset="DOCN%DOM" grid="a%0.47x0.63.*_oi%0.47x0.63"				>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_c061106.nc</value>
-      <value compset="DOCN%DOM" grid="a%0.23x0.31.*_oi%0.23x0.31"				>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_c110526.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid=".+"				>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_1850_2012_c130411.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%T31.*_oi%T31"		>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_1850_2012_c130411.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%1.9x2.5.*_oi%1.9x2.5"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_1850_2012_c130411.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.9x1.25.*_oi%0.9x1.25"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_1850_2012_c130411.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.47x0.63.*_oi%0.47x0.63"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_1850_2012_c130411.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.23x0.31.*_oi%0.23x0.31"	>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_1850_2012_c130411.nc</value>
-      <value compset="1850_" grid=".+"								>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_pi_c101029.nc</value>
-      <value compset="1850_" grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_clim_pi_c101028.nc</value>
-      <value compset="1850_" grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_clim_pi_c101028.nc</value>
-      <value compset="1850_" grid="a%0.9x1.25.*_oi%0.9x1.25"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_pi_c101028.nc</value>
-      <value compset="1850_" grid="a%0.47x0.63.*_oi%0.47x0.63"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_pi_c101028.nc</value>
-      <value compset="1850_" grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_pi_c101028.nc</value>
-      <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
-      <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF" 				        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
-      <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"      grid="a%4x5.*_m%gx3v7"	        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_4x5_clim_c110526.nc</value>
-      <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF"      grid="a%4x5.*_m%gx3v7"	        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_4x5_clim_c110526.nc</value>
+      <value compset="DOCN%DOM" grid="a%T31.*_oi%T31"             >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_clim_c050526.nc</value>
+      <value compset="DOCN%DOM" grid="a%1.9x2.5.*_oi%1.9x2.5"     >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_clim_c061031.nc</value>
+      <value compset="DOCN%DOM" grid="a%0.9x1.25.*_oi%0.9x1.25"   >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
+      <value compset="DOCN%DOM" grid="a%0.47x0.63.*_oi%0.47x0.63" >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_c061106.nc</value>
+      <value compset="DOCN%DOM" grid="a%0.23x0.31.*_oi%0.23x0.31" >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_c110526.nc</value>
+
+      <value compset="(HIST_|20TR_|5505_|TSCH)" grid=".+"                         >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_1850_2017_c180507.nc</value>
+      <value compset="(HIST_|20TR_|5505_|TSCH)" grid="a%T31.*_oi%T31"             >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_1850_2017_c180507.nc</value>
+      <value compset="(HIST_|20TR_|5505_|TSCH)" grid="a%1.9x2.5.*_oi%1.9x2.5"     >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_1850_2017_c180507.nc</value>
+      <value compset="(HIST_|20TR_|5505_|TSCH)" grid="a%0.9x1.25.*_oi%0.9x1.25"   >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_1850_2017_c180507.nc</value>
+      <value compset="(HIST_|20TR_|5505_|TSCH)" grid="a%0.47x0.63.*_oi%0.47x0.63" >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_1850_2017_c180507.nc</value>
+      <value compset="(HIST_|20TR_|5505_|TSCH)" grid="a%0.23x0.31.*_oi%0.23x0.31" >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_1850_2017_c180507.nc</value>
+
+      <value compset="1850_" grid=".+"                         >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_clim_pi_c101029.nc</value>
+      <value compset="1850_" grid="a%T31.*_oi%T31"             >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_clim_pi_c101028.nc</value>
+      <value compset="1850_" grid="a%1.9x2.5.*_oi%1.9x2.5"     >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_clim_pi_c101028.nc</value>
+      <value compset="1850_" grid="a%0.9x1.25.*_oi%0.9x1.25"   >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_pi_c101028.nc</value>
+      <value compset="1850_" grid="a%0.47x0.63.*_oi%0.47x0.63" >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_clim_pi_c101028.nc</value>
+      <value compset="1850_" grid="a%0.23x0.31.*_oi%0.23x0.31" >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_clim_pi_c101028.nc</value>
+
+      <!-- fSST : evolving NorESM derived -->
+      <value compset="HIST_CAM60%NORESM%NORBC"   grid="a%1.9x2.5.*_oi%1.9x2.5.*_m%tnx1v4" >$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_NHIST_f19_tn14_20190625_1849-2015_series_version20190726_ts.nc</value>
+      <value compset="SSP370_CAM60%NORESM%NORBC" grid="a%1.9x2.5.*_oi%1.9x2.5.*_m%tnx1v4" >$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_NSSP370frc2_f19_tn14_20191014_2014-2101_series_version20200109_ts.nc</value>
+
+      <!-- fSST : constant preindustrial NorESM derived -->
+      <value compset="1850_CAM60%NORESM%NORBC"   grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%tnx1v4">$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_N1850frc2_f09_tn14_20191012_1351-1380_series_version20200106_clim.nc</value>
+      <value compset="1850_CAM60%NORESM%NORBC"   grid="a%1.9x2.5.*_oi%1.9x2.5.*_m%tnx1v4"  >$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_N1850_f19_tn14_20190621_1751-1780_series_version20190726_clim.nc</value>
+      <value compset="CAM60%NORESM%NORPIBC"      grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%tnx1v4">$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_N1850frc2_f09_tn14_20191012_1351-1380_series_version20200106_clim.nc</value>
+      <value compset="CAM60%NORESM%NORPIBC"      grid="a%1.9x2.5.*_oi%1.9x2.5.*_m%tnx1v4"  >$DIN_LOC_ROOT/noresm-only/atm/cam/sst/fice-micom-divocn_sst-micom-dow_N1850_f19_tn14_20190621_1751-1780_series_version20190726_clim.nc</value>
+
+      <value compset="2000" grid=".+"                             >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_2000climo_c180511.nc</value>
+      <value compset="2000" grid="a%T31.*_oi%T31"                 >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_2000climo_c180511.nc</value>
+      <value compset="2000" grid="a%1.9x2.5.*_oi%1.9x2.5"         >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_2000climo_c180511.nc</value>
+      <value compset="2000" grid="a%0.9x1.25.*_oi%0.9x1.25"       >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_2000climo_c180511.nc</value>
+      <value compset="2000" grid="a%0.47x0.63.*_oi%0.47x0.63"     >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_2000climo_c180511.nc</value>
+      <value compset="2000" grid="a%0.23x0.31.*_oi%0.23x0.31"     >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_2000climo_c180511.nc</value>
+
+      <value compset="2000_CAM60%WCTS" grid="a%0.9x1.25.*_oi%0.9x1.25" >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
+      <value compset="2000_CAM60%WCTS" grid="a%1.9x2.5.*_oi%1.9x2.5"   >$DIN_LOC_ROOT/atm/cam/sst/f2000.waccm-mam3_1.9x2.5_L70.cam2.i.0017-01-01.c120410.nc</value>
+
+      <value compset="2010" grid=".+"                         >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1x1_2010climo_c180511.nc</value>
+      <value compset="2010" grid="a%T31.*_oi%T31"             >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_48x96_2010climo_c180511.nc</value>
+      <value compset="2010" grid="a%1.9x2.5.*_oi%1.9x2.5"     >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_1.9x2.5_2010climo_c180511.nc</value>
+      <value compset="2010" grid="a%0.9x1.25.*_oi%0.9x1.25"   >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_2010climo_c180511.nc</value>
+      <value compset="2010" grid="a%0.47x0.63.*_oi%0.47x0.63" >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.47x0.63_2010climo_c180511.nc</value>
+      <value compset="2010" grid="a%0.23x0.31.*_oi%0.23x0.31" >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.23x0.31_2010climo_c180511.nc</value>
+
+      <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"                        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
+      <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF"                        >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_0.9x1.25_clim_c040926.nc</value>
+      <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" grid="a%4x5.*_m%gx3v7" >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_4x5_clim_c110526.nc</value>
+      <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF" grid="a%4x5.*_m%gx3v7" >$DIN_LOC_ROOT/atm/cam/sst/sst_HadOIBl_bc_4x5_clim_c110526.nc</value>
     </values>
     <group>run_component_docn</group>
     <file>env_run.xml</file>
@@ -183,31 +213,19 @@
     <type>char</type>
     <valid_values></valid_values>
     <default_value>$DIN_LOC_ROOT/ocn/docn7/domain.ocn.1x1.111007.nc</default_value>
-    <values match="last">
-      <value compset="DOCN%DOM" grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.48x96_gx3v7_100114.nc</value>
-      <value compset="DOCN%DOM" grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.1.9x2.5_gx1v6_090403.nc </value>
-      <value compset="DOCN%DOM" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v6"			>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
-      <value compset="DOCN%DOM" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v7"			>$DIN_LOC_ROOT/share/domains/domain.ocn.fv0.9x1.25_gx1v7.151020.nc</value>
-      <value compset="DOCN%DOM" grid="a%0.47x0.63.*_oi%0.47x0.63"				>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.47x0.63_gx1v6_090408.nc</value>
-      <value compset="DOCN%DOM" grid="a%0.23x0.31.*_oi%0.23x0.31"				>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.23x0.31_gx1v6_101108.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid=".+"				>$DIN_LOC_ROOT/ocn/docn7/domain.ocn.1x1.111007.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%T31.*_oi%T31"			>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.48x96_gx3v7_100114.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%1.9x2.5.*_oi%1.9x2.5"		>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.1.9x2.5_gx1v6_090403.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v6"  >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v7"	>$DIN_LOC_ROOT/share/domains/domain.ocn.fv0.9x1.25_gx1v7.151020.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.47x0.63.*_oi%0.47x0.63"	>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.47x0.63_gx1v6_090408.nc</value>
-      <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)" grid="a%0.23x0.31.*_oi%0.23x0.31"	>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.23x0.31_gx1v6_101108.nc</value>
-      <value compset="1850" grid=".+"								>$DIN_LOC_ROOT/ocn/docn7/domain.ocn.1x1.111007.nc</value>
-      <value compset="1850" grid="a%T31.*_oi%T31"						>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.48x96_gx3v7_100114.nc</value>
-      <value compset="1850" grid="a%1.9x2.5.*_oi%1.9x2.5"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.1.9x2.5_gx1v6_090403.nc</value>
-      <value compset="1850" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v6"			        >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
-      <value compset="1850" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v7"				>$DIN_LOC_ROOT/share/domains/domain.ocn.fv0.9x1.25_gx1v7.151020.nc</value>
-      <value compset="1850" grid="a%0.47x0.63.*_oi%0.47x0.63"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.47x0.63_gx1v6_090408.nc</value>
-      <value compset="1850" grid="a%0.23x0.31.*_oi%0.23x0.31"					>$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.23x0.31_gx1v6_101108.nc</value>
-      <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"                                         >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
-      <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF"                                         >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
-      <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" grid="a%4x5.*_m%gx3v7"                  >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.4x5_gx3v7_100120.nc</value>
-      <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF" grid="a%4x5.*_m%gx3v7"                  >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.4x5_gx3v7_100120.nc</value>
+    <values match="first">
+      <value compset="DOCN%DOM" grid="a%T31.*_oi%T31"                          >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.48x96_gx3v7_100114.nc</value>
+      <value compset="DOCN%DOM" grid="a%1.9x2.5.*_oi%1.9x2.5.*_m%gx3v6"        >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.1.9x2.5_gx1v6_090403.nc </value>
+      <value compset="DOCN%DOM" grid="a%1.9x2.5.*_oi%1.9x2.5.*_m%tnx1v4"       >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.ocn.fv1.9x2.5_tnx1v4.170609_djlo.nc</value>
+      <value compset="DOCN%DOM" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v6"      >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
+      <value compset="DOCN%DOM" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%gx1v7"      >$DIN_LOC_ROOT/share/domains/domain.ocn.fv0.9x1.25_gx1v7.151020.nc</value>
+      <value compset="DOCN%DOM" grid="a%0.9x1.25.*_oi%0.9x1.25.*_m%tnx1v4"     >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.ocn.fv0.9x1.25_tnx1v4.170609_djlo.nc</value>
+      <value compset="DOCN%DOM" grid="a%0.47x0.63.*_oi%0.47x0.63.*_m%gx1v6"    >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.47x0.63_gx1v6_090408.nc</value>
+      <value compset="DOCN%DOM" grid="a%0.23x0.31.*_oi%0.23x0.31.*_m%gx1v6"    >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.23x0.31_gx1v6_101108.nc</value>
+      <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF"                        >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
+      <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF"                        >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.0.9x1.25_gx1v6_090403.nc</value>
+      <value compset="DATM.*_DLND.*_DICE.*_DOCN.*_DROF" grid="a%4x5.*_m%gx3v7" >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.4x5_gx3v7_100120.nc</value>
+      <value compset="DATM.*_SLND.*_DICE.*_DOCN.*_DROF" grid="a%4x5.*_m%gx3v7" >$DIN_LOC_ROOT/atm/cam/ocnfrac/domain.camocn.4x5_gx3v7_100120.nc</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -264,8 +282,8 @@
     <default_value>0</default_value>
     <values match="last">
       <value compset="(AMIP_|HIST_|20TR_|5505_|PIPD_|%TSCH)">2012</value>
-      <value compset="(HIST_CAM60%NORESM%NORBC)">2015</value>
       <value compset="(CAM60%NORESM%NORPIBC)">0</value>
+      <value compset="HIST_">2016</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>

--- a/src/drivers/mct/cime_config/config_component.xml
+++ b/src/drivers/mct/cime_config/config_component.xml
@@ -643,6 +643,10 @@
     <valid_values>NO_LEAP,GREGORIAN</valid_values>
     <default_value>NO_LEAP</default_value>
     <group>build_def</group>
+    <values match="last">
+ 	    <value compset="HIST_CAM40%WX">GREGORIAN</value>
+	    <value compset="%SDYN">GREGORIAN</value>
+    </values>
     <file>env_build.xml</file>
     <desc>calendar type</desc>
   </entry>
@@ -661,6 +665,9 @@
     <valid_values>TRUE,FALSE</valid_values>
     <default_value>FALSE</default_value>
     <group>build_def</group>
+    <values match="last">
+      <value compset="_CAM40%WXIE">TRUE</value>
+    </values>
     <file>env_build.xml</file>
     <desc>TRUE implies using the ESMF library specified by ESMF_LIBDIR or ESMFMKFILE</desc>
   </entry>

--- a/src/drivers/mct/cime_config/config_component_cesm.xml
+++ b/src/drivers/mct/cime_config/config_component_cesm.xml
@@ -232,6 +232,7 @@
       <value compset="_CAM\d+%WCBC">144</value>
       <value compset="_CAM\d+%WCMX">288</value>
       <value compset="_CAM\d+%WCXI">288</value>
+      <value compset="_CAM40%WX">288</value>
       <value compset="_DATM%COPYALL_NPS">72</value>
       <value compset="_DATM.*_CLM">48</value>
       <value compset="_DATM.*_DICE.*_POP2">4</value>


### PR DESCRIPTION
The main purpose of this PR is to update the config_grids.xml so that it can handle F compset cam grids correctly. Previously, the domain files for lnd and ocn for the mask of tnx1v4 was set in cam's config_compset.xml. This PR creates the correct way to implement these grids in config_grids.xml. This PR must also be accompanied by https://github.com/NorESMhub/CAM/pull/116.
In addition, deprecated machines have been removed from config_machines.xml, config_compilers.xml and config_batch.xml

Testing:
Along with the CAM PR mentioned above - the following tests were run and a baseline was created in 
```
SMS_D_Ln9.f19_f19_mtn14.NF1850norbc.betzy_intel.cam-outfrq9s
SMS_D_Ln9.f19_f19_mtn14.NF1850norbc_aer2014.betzy_intel.cam-outfrq9s
ERP_Ln9.f19_f19_mtn14.NF1850norbc.betzy_intel.cam-outfrq9s
ERP_Ln9.f19_f19_mtn14.NF1850norbc_aer2014.betzy_intel.cam-outfrq9s
ERP_Ln9.f09_f09_mtn14.NF1850frc2norbc.betzy_intel.cam-outfrq9s
ERP_Ln9.f09_f09_mtn14.NF1850frc2norbc_aer2014.betzy_intel.cam-outfrq9s
ERP_Ln9.f09_f09_mtn14.NFHISTnorpddmsbc.betzy_intel.cam-outfrq9s
ERP_Ln9.f19_f19_mtn14.FHS94.betzy_intel.cam-outfrq9s
```
and a baseline noresm2_1_develop_20112023 was created

Fixes:
User interface changes?: No
Update gh-pages html (Y/N)?: No

