### PR TITLE
Fix error message format

### DIFF
--- a/scripts/lib/CIME/test_scheduler.py
+++ b/scripts/lib/CIME/test_scheduler.py
@@ -760,7 +760,7 @@ class TestScheduler(object):
 
         if not success:
             status_str += "\n    Case dir: {}\n".format(self._get_test_dir(test))
-            status_str += "    Errors were:\n        {}\n".format("\n        ".join(errors.encode('utf-8').splitlines()))
+            status_str += "    Errors were:\n        {}\n".format("\n        ".join(errors.splitlines()))
 
         logger.info(status_str)
 


### PR DESCRIPTION
Fix format of error message in test_scheduler.py to not crash (had mixed strings and bytes).

Test suite: Tried create_test with bad resolution to trigger error
Test status: bit for bit

Fixes #59 

User interface changes?: No

Update gh-pages html (Y/N)?: N