### PR TITLE
Updates for NorESM2.1

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -158,49 +158,49 @@
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="T42_T42_musgs" not_compset="_POP|_BLOM">
+    <model_grid alias="T42_T42_musgs" compset="_DOCN|_SOCN">
       <grid name="atm">T42</grid>
       <grid name="lnd">T42</grid>
       <grid name="ocnice">T42</grid>
       <mask>usgs</mask>
     </model_grid>
 
-    <model_grid alias="T42_T42" not_compset="_POP|_BLOM">
+    <model_grid alias="T42_T42" compset="_DOCN|_SOCN">
       <grid name="atm">T42</grid>
       <grid name="lnd">T42</grid>
       <grid name="ocnice">T42</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="T42_T42_mg16" not_compset="_POP|_BLOM">
+    <model_grid alias="T42_T42_mg16" compset="_DOCN|_SOCN">
       <grid name="atm">T42</grid>
       <grid name="lnd">T42</grid>
       <grid name="ocnice">T42</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="T42_T42_mg17" not_compset="_POP|_BLOM">
+    <model_grid alias="T42_T42_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">T42</grid>
       <grid name="lnd">T42</grid>
       <grid name="ocnice">T42</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="T85_T85_mg16" not_compset="_POP|_BLOM">
+    <model_grid alias="T85_T85_mg16" compset="_DOCN|_SOCN">
       <grid name="atm">T85</grid>
       <grid name="lnd">T85</grid>
       <grid name="ocnice">T85</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="T85_T85_mg17" not_compset="_POP|_BLOM">
+    <model_grid alias="T85_T85_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">T85</grid>
       <grid name="lnd">T85</grid>
       <grid name="ocnice">T85</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="T85_T85_musgs" not_compset="_POP|_BLOM">
+    <model_grid alias="T85_T85_musgs" compset="_DOCN|_SOCN">
       <grid name="atm">T85</grid>
       <grid name="lnd">T85</grid>
       <grid name="ocnice">T85</grid>
@@ -461,42 +461,42 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09" compset="_DOCN" >
+    <model_grid alias="f09_f09" compset="_DOCN|_SOCN" >
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
       <mask>tnx1v4</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_mtn14" compset="_DOCN" >
+    <model_grid alias="f09_f09_mtn14" compset="_DOCN|_SOCN" >
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
       <mask>tnx1v4</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_mg16" compset="_DOCN" >
+    <model_grid alias="f09_f09_mg16" compset="_DOCN|_SOCN" >
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_mg17" compset="_DOCN" >
+    <model_grid alias="f09_f09_mg17" compset="_DOCN|_SOCN" >
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="f05_f05_mg17" compset="_DOCN" >
+    <model_grid alias="f05_f05_mg17" compset="_DOCN|_SOCN" >
       <grid name="atm">0.47x0.63</grid>
       <grid name="lnd">0.47x0.63</grid>
       <grid name="ocnice">0.47x0.63</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_gl5" compset="_CISM" not_compset="_POP|_BLOM">
+    <model_grid alias="f09_f09_gl5" compset="(_DOCN|_SOCN).*_CISM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
@@ -504,7 +504,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_gl5_mg16" compset="_CISM" not_compset="_POP|_BLOM">
+    <model_grid alias="f09_f09_gl5_mg16" compset="(_DOCN|_SOCN).*_CISM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
@@ -512,7 +512,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_gl5_mg17" compset="_CISM" not_compset="_POP|_BLOM">
+    <model_grid alias="f09_f09_gl5_mg17" compset="(_DOCN|_SOCN).*_CISM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
@@ -582,7 +582,7 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_gl5" compset="_CISM" not_compset="_POP|_BLOM">
+    <model_grid alias="f19_f19_gl5" compset="(_DOCN|_SOCN).*_CISM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
@@ -590,7 +590,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_gl5_mg16" compset="_CISM" not_compset="_POP|_BLOM">
+    <model_grid alias="f19_f19_gl5_mg16" compset="(_DOCN|_SOCN).*_CISM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
@@ -598,7 +598,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_gl5_mg17" compset="_CISM" not_compset="_POP|_BLOM">
+    <model_grid alias="f19_f19_gl5_mg17" compset="(_DOCN|_SOCN).*_CISM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
@@ -606,28 +606,28 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19" not_compset="_POP|_BLOM">
+    <model_grid alias="f19_f19" compset="_DOCN|_SOCN">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
       <mask>tnx1v4</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_mtn14" not_compset="_POP|_BLOM">
+    <model_grid alias="f19_f19_mtn14" compset="_DOCN|_SOCN">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
       <mask>tnx1v4</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_mg16" not_compset="_POP|_BLOM">
+    <model_grid alias="f19_f19_mg16" compset="_DOCN|_SOCN">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_f19_mg17" not_compset="_POP|_BLOM">
+    <model_grid alias="f19_f19_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">1.9x2.5</grid>
@@ -641,49 +641,49 @@
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="f02_f02_mg16" not_compset="_POP|_BLOM">
+    <model_grid alias="f02_f02_mg16" compset="_DOCN|_SOCN">
       <grid name="atm">0.23x0.31</grid>
       <grid name="lnd">0.23x0.31</grid>
       <grid name="ocnice">0.23x0.31</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f02_f02_mg17" not_compset="_POP|_BLOM">
+    <model_grid alias="f02_f02_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">0.23x0.31</grid>
       <grid name="lnd">0.23x0.31</grid>
       <grid name="ocnice">0.23x0.31</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="f25_f25_mg16" not_compset="_POP|_BLOM">
+    <model_grid alias="f25_f25_mg16" compset="_DOCN|_SOCN">
       <grid name="atm">2.5x3.33</grid>
       <grid name="lnd">2.5x3.33</grid>
       <grid name="ocnice">2.5x3.33</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f25_f25_mg17" not_compset="_POP|_BLOM">
+    <model_grid alias="f25_f25_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">2.5x3.33</grid>
       <grid name="lnd">2.5x3.33</grid>
       <grid name="ocnice">2.5x3.33</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="f45_f45_mg37" not_compset="_POP|_BLOM">
+    <model_grid alias="f45_f45_mg37" compset="_DOCN|_SOCN">
       <grid name="atm">4x5</grid>
       <grid name="lnd">4x5</grid>
       <grid name="ocnice">4x5</grid>
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="f10_f10_mg37" not_compset="_POP|_BLOM">
+    <model_grid alias="f10_f10_mg37" compset="_DOCN|_SOCN">
       <grid name="atm">10x15</grid>
       <grid name="lnd">10x15</grid>
       <grid name="ocnice">10x15</grid>
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="f10_f10_musgs" not_compset="_POP|_BLOM">
+    <model_grid alias="f10_f10_musgs" compset="_DOCN|_SOCN">
       <grid name="atm">10x15</grid>
       <grid name="lnd">10x15</grid>
       <grid name="ocnice">10x15</grid>
@@ -800,7 +800,7 @@
     </model_grid>
     <!--  spectral element grids -->
 
-    <model_grid alias="ne5_ne5_mg37" not_compset="_POP|_BLOM">
+    <model_grid alias="ne5_ne5_mg37" compset="_DOCN|_SOCN">
       <grid name="atm">ne5np4</grid>
       <grid name="lnd">ne5np4</grid>
       <grid name="ocnice">ne5np4</grid>
@@ -814,7 +814,7 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne16_ne16_mg17" not_compset="_POP|_BLOM">
+    <model_grid alias="ne16_ne16_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne16np4</grid>
       <grid name="lnd">ne16np4</grid>
       <grid name="ocnice">ne16np4</grid>
@@ -867,14 +867,14 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne30_ne30_mg16" not_compset="_POP|_BLOM">
+    <model_grid alias="ne30_ne30_mg16" compset="_DOCN|_SOCN">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">ne30np4</grid>
       <grid name="ocnice">ne30np4</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne30_ne30_mg17" not_compset="_POP|_BLOM">
+    <model_grid alias="ne30_ne30_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">ne30np4</grid>
       <grid name="ocnice">ne30np4</grid>
@@ -895,7 +895,7 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne60_ne60_mg16" not_compset="_POP|_BLOM">
+    <model_grid alias="ne60_ne60_mg16" compset="_DOCN|_SOCN">
       <grid name="atm">ne60np4</grid>
       <grid name="lnd">ne60np4</grid>
       <grid name="ocnice">ne60np4</grid>
@@ -923,7 +923,7 @@
       <mask>tx0.1v2</mask>
     </model_grid>
 
-    <model_grid alias="ne120_ne120_mg16" not_compset="_POP|_BLOM">
+    <model_grid alias="ne120_ne120_mg16" compset="_DOCN|_SOCN">
       <grid name="atm">ne120np4</grid>
       <grid name="lnd">ne120np4</grid>
       <grid name="ocnice">ne120np4</grid>
@@ -953,14 +953,14 @@
       <mask>tx0.1v2</mask>
     </model_grid>
 
-    <model_grid alias="ne240_ne240_mg16" not_compset="_POP|_BLOM">
+    <model_grid alias="ne240_ne240_mg16" compset="_DOCN|_SOCN">
       <grid name="atm">ne240np4</grid>
       <grid name="lnd">ne240np4</grid>
       <grid name="ocnice">ne240np4</grid>
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne240_ne240_mg17" not_compset="_POP|_BLOM">
+    <model_grid alias="ne240_ne240_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne240np4</grid>
       <grid name="lnd">ne240np4</grid>
       <grid name="ocnice">ne240np4</grid>
@@ -999,7 +999,7 @@
 
     <!--  spectral element grids with 3x3 FVM physics grid -->
 
-    <model_grid alias="ne5pg3_ne5pg3_mg37" not_compset="_POP|_BLOM">
+    <model_grid alias="ne5pg3_ne5pg3_mg37" compset="_DOCN|_SOCN">
       <grid name="atm">ne5np4.pg3</grid>
       <grid name="lnd">ne5np4.pg3</grid>
       <grid name="ocnice">ne5np4.pg3</grid>
@@ -1066,14 +1066,14 @@
 
    <!-- VR-CESM grids with CAM-SE -->
 
-    <model_grid alias="ne0TESTONLYne5x4_ne0TESTONLYne5x4_mg37" not_compset="_POP|_BLOM">
+    <model_grid alias="ne0TESTONLYne5x4_ne0TESTONLYne5x4_mg37" compset="_DOCN|_SOCN">
       <grid name="atm">ne0np4TESTONLY.ne5x4</grid>
       <grid name="lnd">ne0np4TESTONLY.ne5x4</grid>
       <grid name="ocnice">ne0np4TESTONLY.ne5x4</grid>
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="ne0CONUSne30x8_ne0CONUSne30x8_mt12" not_compset="_POP|_BLOM">
+    <model_grid alias="ne0CONUSne30x8_ne0CONUSne30x8_mt12" compset="_DOCN|_SOCN">
       <grid name="atm">ne0np4CONUS.ne30x8</grid>
       <grid name="lnd">ne0np4CONUS.ne30x8</grid>
       <grid name="ocnice">ne0np4CONUS.ne30x8</grid>

--- a/scripts/Tools/standard_script_setup.py
+++ b/scripts/Tools/standard_script_setup.py
@@ -14,6 +14,6 @@ sys.path.append(_LIB_DIR)
 os.environ["CIMEROOT"] = _CIMEROOT
 
 import CIME.utils
-CIME.utils.check_minimum_python_version(2, 7)
+CIME.utils.check_minimum_python_version(3, 8)
 CIME.utils.stop_buffering_output()
 import logging, argparse

--- a/scripts/lib/CIME/case/case.py
+++ b/scripts/lib/CIME/case/case.py
@@ -1335,12 +1335,14 @@ directory, NOT in this subdirectory."""
             tests = Testlist(tests_spec_file, files)
             testlist = tests.get_tests(compset=compset_alias, grid=grid_name, supported_only=True)
             for test in testlist:
-                if test["category"] == "prealpha" or test["category"] == "prebeta" or "aux_" in test["category"]:
+                if any([x in test["category"] for x in ("prealpha_noresm", "aux_")]):
                     testcnt += 1
+
         if testcnt > 0:
-            logger.warning("\n*********************************************************************************************************************************")
-            logger.warning("This compset and grid combination is not scientifically supported, however it is used in {:d} tests.".format(testcnt))
-            logger.warning("*********************************************************************************************************************************\n")
+            wmsg=f"This compset and grid combination is not scientifically supported, however it is used in {testcnt:d} tests."
+            logger.warning(f"\n{'*'*len(wmsg)}")
+            logger.warning(wmsg)
+            logger.warning(f"{'*'*len(wmsg)}\n")
         else:
             expect(False, "\nThis compset and grid combination is untested in CESM.  "
                    "Override this warning with the --run-unsupported option to create_newcase.",


### PR DESCRIPTION
- Update min python to 3.8 (oldest supported version)
- Correct restrictions on grids that do not support an active ocean component
- Bring supported test categories in line with NorESM testing
    - `prealpha_noresm`: For testing before making any alpha or release tag
    - `aux_<xxx>`: For component-specific pre-tag testing (e.g., `aux_cam_noresm`, `aux_clm`).

Test suite: Ran `create_newcase` against all CAM and NorESM compsets
Test baseline: NA
Test namelist changes: No
Test status: BfB

Closes #61 
Closes #62 
Closes #64 

User interface changes?: Supported test suite names now `prealpha_noresm` and `aux_<xxx>`.
