### PR TITLE
Force CIME CCS to use correct Python

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2364,6 +2364,7 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">iompi/2020a</command>
         <command name="load">NCO/4.9.7-iomkl-2020a</command>
         <command name="load">CMake/3.12.1</command>
+        <command name="load">Python/3.9.6-GCCcore-11.2.0</command>
       </modules>
     </module_system>
     <environment_variables>


### PR DESCRIPTION
Attempt to ensure that the CIME CCS always has access to a valid version of Python by loading it as a module inside the case.

Tested by logging in with a 'bare' (no Python loaded)  shell, loading a valid Python (tested 3.8.2, 3.9.6, and 3.11.3), and building (and running) a case.