### PR TITLE
Fixed entries where BLOM should not be allowed

### DIFF
--- a/config/cesm/config_grids.xml
+++ b/config/cesm/config_grids.xml
@@ -357,7 +357,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f02_g17">
+    <model_grid alias="f02_g17" not_compset="_BLOM">
       <grid name="atm">0.23x0.31</grid>
       <grid name="lnd">0.23x0.31</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -385,7 +385,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f05_g17">
+    <model_grid alias="f05_g17" not_compset="_BLOM">
       <grid name="atm">0.47x0.63</grid>
       <grid name="lnd">0.47x0.63</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -406,7 +406,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f09_g17">
+    <model_grid alias="f09_g17" not_compset="_BLOM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -421,7 +421,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f09_g17_gl4" compset="_CISM">
+    <model_grid alias="f09_g17_gl4" compset="_CISM" not_compset="_BLOM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -437,7 +437,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f09_g17_gl20" compset="_CISM">
+    <model_grid alias="f09_g17_gl20" compset="_CISM" not_compset="_BLOM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -453,7 +453,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f09_g17_gl5" compset="_CISM">
+    <model_grid alias="f09_g17_gl5" compset="_CISM" not_compset="_BLOM">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -482,7 +482,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f09_f09_mg17" compset="_DOCN|_SOCN" >
+    <model_grid alias="f09_f09_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">0.9x1.25</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">0.9x1.25</grid>
@@ -527,7 +527,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_g17">
+    <model_grid alias="f19_g17" not_compset="_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -542,7 +542,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_g17_r01">
+    <model_grid alias="f19_g17_r01" not_compset="_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -558,7 +558,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_g17_gl4" compset="_CISM">
+    <model_grid alias="f19_g17_gl4" compset="_CISM" not_compset="_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -574,7 +574,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_g17_gl5" compset="_CISM">
+    <model_grid alias="f19_g17_gl5" compset="_CISM" not_compset="_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -769,20 +769,6 @@
       <mask>tnx1v4</mask>
     </model_grid>
 
-    <model_grid alias="f19_g16" not_compset="_BLOM">
-      <grid name="atm">1.9x2.5</grid>
-      <grid name="lnd">1.9x2.5</grid>
-      <grid name="ocnice">gx1v6</grid>
-    </model_grid>
-
-    <model_grid alias="f19_g16_gl4" not_compset="_BLOM">
-      <grid name="atm">1.9x2.5</grid>
-      <grid name="lnd">1.9x2.5</grid>
-      <grid name="ocnice">gx1v6</grid>
-      <grid name="glc">gland4</grid>
-      <mask>gx1v6</mask>
-    </model_grid>
-
     <model_grid alias="f19_tn14_gl4" not_compset="_POP">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
@@ -821,7 +807,7 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne30_g16" not_compset="_BLOM">
+    <model_grid alias="ne30_g16">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">ne30np4</grid>
       <grid name="ocnice">gx1v6</grid>
@@ -835,7 +821,7 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne30_f19_g16" not_compset="_BLOM">
+    <model_grid alias="ne30_f19_g16">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">gx1v6</grid>
@@ -851,7 +837,7 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne30_f09_g16" not_compset="_BLOM">
+    <model_grid alias="ne30_f09_g16">
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">0.9x1.25</grid>
       <grid name="ocnice">gx1v6</grid>
@@ -881,7 +867,7 @@
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne60_g16" not_compset="_BLOM">
+    <model_grid alias="ne60_g16">
       <grid name="atm">ne60np4</grid>
       <grid name="lnd">ne60np4</grid>
       <grid name="ocnice">gx1v6</grid>
@@ -902,7 +888,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne120_g16" not_compset="_BLOM">
+    <model_grid alias="ne120_g16">
       <grid name="atm">ne120np4</grid>
       <grid name="lnd">ne120np4</grid>
       <grid name="ocnice">gx1v6</grid>
@@ -930,7 +916,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne240_f02_g16" not_compset="_BLOM">
+    <model_grid alias="ne240_f02_g16">
       <grid name="atm">ne240np4</grid>
       <grid name="lnd">0.23x0.31</grid>
       <grid name="ocnice">gx1v6</grid>
@@ -969,28 +955,28 @@
 
     <!--  spectral element grids with 2x2 FVM physics grid -->
 
-    <model_grid alias="ne30pg2_ne30pg2_mg17" not_compset="_POP|_BLOM|_CLM">
+    <model_grid alias="ne30pg2_ne30pg2_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">ne30np4.pg2</grid>
       <grid name="ocnice">ne30np4.pg2</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne60pg2_ne60pg2_mg17" not_compset="_POP|_BLOM|_CLM">
+    <model_grid alias="ne60pg2_ne60pg2_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne60np4.pg2</grid>
       <grid name="lnd">ne60np4.pg2</grid>
       <grid name="ocnice">ne60np4.pg2</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne120pg2_ne120pg2_mg17" not_compset="_POP|_BLOM|_CLM">
+    <model_grid alias="ne120pg2_ne120pg2_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne120np4.pg2</grid>
       <grid name="lnd">ne120np4.pg2</grid>
       <grid name="ocnice">ne120np4.pg2</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne240pg2_ne240pg2_mg17" not_compset="_POP|_BLOM|_CLM">
+    <model_grid alias="ne240pg2_ne240pg2_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne240np4.pg2</grid>
       <grid name="lnd">ne240np4.pg2</grid>
       <grid name="ocnice">ne240np4.pg2</grid>
@@ -1006,35 +992,35 @@
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="ne16pg3_ne16pg3_mg37" not_compset="_POP|_BLOM|_CLM">
+    <model_grid alias="ne16pg3_ne16pg3_mg37" compset="_DOCN|_SOCN">
       <grid name="atm">ne16np4.pg3</grid>
       <grid name="lnd">ne16np4.pg3</grid>
       <grid name="ocnice">ne16np4.pg3</grid>
       <mask>gx3v7</mask>
     </model_grid>
 
-    <model_grid alias="ne30pg3_ne30pg3_mg17" not_compset="_POP|_BLOM|_CLM">
+    <model_grid alias="ne30pg3_ne30pg3_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne30np4.pg3</grid>
       <grid name="lnd">ne30np4.pg3</grid>
       <grid name="ocnice">ne30np4.pg3</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne60pg3_ne60pg3_mg17" not_compset="_POP|_BLOM|_CLM">
+    <model_grid alias="ne60pg3_ne60pg3_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne60np4.pg3</grid>
       <grid name="lnd">ne60np4.pg3</grid>
       <grid name="ocnice">ne60np4.pg3</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne120pg3_ne120pg3_mg17" not_compset="_POP|_BLOM|_CLM">
+    <model_grid alias="ne120pg3_ne120pg3_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne120np4.pg3</grid>
       <grid name="lnd">ne120np4.pg3</grid>
       <grid name="ocnice">ne120np4.pg3</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne240pg3_ne240pg3_mg17" not_compset="_POP|_BLOM|_CLM">
+    <model_grid alias="ne240pg3_ne240pg3_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne240np4.pg3</grid>
       <grid name="lnd">ne240np4.pg3</grid>
       <grid name="ocnice">ne240np4.pg3</grid>
@@ -1043,21 +1029,21 @@
 
     <!--  spectral element grids with 4x4 FVM physics grid -->
 
-    <model_grid alias="ne30pg4_ne30pg4_mg17" not_compset="_POP|_BLOM|_CLM">
+    <model_grid alias="ne30pg4_ne30pg4_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne30np4.pg4</grid>
       <grid name="lnd">ne30np4.pg4</grid>
       <grid name="ocnice">ne30np4.pg4</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne60pg4_ne60pg4_mg17" not_compset="_POP|_BLOM|_CLM">
+    <model_grid alias="ne60pg4_ne60pg4_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne60np4.pg4</grid>
       <grid name="lnd">ne60np4.pg4</grid>
       <grid name="ocnice">ne60np4.pg4</grid>
       <mask>gx1v7</mask>
     </model_grid>
 
-    <model_grid alias="ne120pg4_ne120pg4_mg17" not_compset="_POP|_BLOM|_CLM">
+    <model_grid alias="ne120pg4_ne120pg4_mg17" compset="_DOCN|_SOCN">
       <grid name="atm">ne120np4.pg4</grid>
       <grid name="lnd">ne120np4.pg4</grid>
       <grid name="ocnice">ne120np4.pg4</grid>
@@ -1103,7 +1089,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="f19_g17_rx1" compset="_DROF">
+    <model_grid alias="f19_g17_rx1" compset="_DROF" not_compset="_BLOM">
       <grid name="atm">1.9x2.5</grid>
       <grid name="lnd">1.9x2.5</grid>
       <grid name="ocnice">gx1v7</grid>
@@ -1117,7 +1103,7 @@
       <mask>gx1v6</mask>
     </model_grid>
 
-    <model_grid alias="ne30_g17_rx1" compset="_DROF">
+    <model_grid alias="ne30_g17_rx1" compset="_DROF" >
       <grid name="atm">ne30np4</grid>
       <grid name="lnd">ne30np4</grid>
       <grid name="ocnice">gx1v7</grid>


### PR DESCRIPTION
- added not_compset="_BLOM" to all grids with gx1v7 ocean
- removed duplicate entries where the second entry was incorrect 
- made all entries where OCN grid was same as ATM grid as compset=DOCN|SOCN

Test suite:
Test baseline:
Test namelist changes:
Test status: 

Fixes [CIME Github issue #66 

User interface changes?: No

Update gh-pages html (Y/N)?: No
