### PR TITLE
Revert "Module commands update for easybuild 4.9.0 on betzy"

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2357,12 +2357,14 @@ This allows using a different mpirun command to launch unit tests
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules compiler="intel">
-        <command name="--quiet restore"></command>
-        <command name="--quiet load">NESSI/2023.06</command>
+        <command name="--quiet restore">system</command>
         <command name="load">StdEnv</command>
-        <command name="load">NCO/5.1.9-iomkl-2022a</command>
-        <command name="load">Python/3.10.4-GCCcore-11.3.0</command>
-        <command name="load">CMake/3.23.1-GCCcore-11.3.0</command>
+        <command name="load">intel/2020a</command>
+        <command name="load">netCDF-Fortran/4.5.2-iompi-2020a</command>
+        <command name="load">iompi/2020a</command>
+        <command name="load">NCO/4.9.7-iomkl-2020a</command>
+        <command name="load">CMake/3.12.1</command>
+        <command name="load">Python/3.9.6-GCCcore-11.2.0</command>
       </modules>
     </module_system>
     <environment_variables>


### PR DESCRIPTION
Reverts NorESMhub/cime#71

Previous changes were only implemented due to LMOD cache failure. Old config should work now