### PR TITLE
Noresm2 3 develop update

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2347,6 +2347,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
     </mpirun>
+
     <module_system type="module">
       <init_path lang="perl">/cluster/installations/lmod/lmod/init/perl</init_path>
       <init_path lang="python">/cluster/installations/lmod/lmod/init/env_modules_python.py</init_path>
@@ -2359,12 +2360,10 @@ This allows using a different mpirun command to launch unit tests
       <modules compiler="intel">
         <command name="--quiet restore">system</command>
         <command name="load">StdEnv</command>
-        <command name="load">intel/2020a</command>
-        <command name="load">netCDF-Fortran/4.5.2-iompi-2020a</command>
-        <command name="load">iompi/2020a</command>
-        <command name="load">NCO/4.9.7-iomkl-2020a</command>
-        <command name="load">CMake/3.12.1</command>
-        <command name="load">Python/3.9.6-GCCcore-11.2.0</command>
+        <command name="load">netCDF-Fortran/4.6.0-iompi-2022a</command>
+        <command name="load">NCO/5.1.9-iomkl-2022a</command>
+        <command name="load">CMake/3.23.1-GCCcore-11.3.0</command>
+        <command name="load">Python/3.10.4-GCCcore-11.3.0</command>
       </modules>
     </module_system>
     <environment_variables>


### PR DESCRIPTION
This updates `noresm2_3_develop` with latest changes from `noresm2_1_develop`, keeping these branches identical.
Alternatively, we could remove one of these branches going forward.

Test suite:
Test baseline:
Test namelist changes:
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]

User interface changes?:

Update gh-pages html (Y/N)?:
