### PR TITLE
Noresm2 3 develop update

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2347,6 +2347,7 @@ This allows using a different mpirun command to launch unit tests
     <mpirun mpilib="default">
       <executable>srun</executable>
     </mpirun>
+
     <module_system type="module">
       <init_path lang="perl">/cluster/installations/lmod/lmod/init/perl</init_path>
       <init_path lang="python">/cluster/installations/lmod/lmod/init/env_modules_python.py</init_path>
@@ -2359,12 +2360,10 @@ This allows using a different mpirun command to launch unit tests
       <modules compiler="intel">
         <command name="--quiet restore">system</command>
         <command name="load">StdEnv</command>
-        <command name="load">intel/2020a</command>
-        <command name="load">netCDF-Fortran/4.5.2-iompi-2020a</command>
-        <command name="load">iompi/2020a</command>
-        <command name="load">NCO/4.9.7-iomkl-2020a</command>
-        <command name="load">CMake/3.12.1</command>
-        <command name="load">Python/3.9.6-GCCcore-11.2.0</command>
+        <command name="load">netCDF-Fortran/4.6.0-iompi-2022a</command>
+        <command name="load">NCO/5.1.9-iomkl-2022a</command>
+        <command name="load">CMake/3.23.1-GCCcore-11.3.0</command>
+        <command name="load">Python/3.10.4-GCCcore-11.3.0</command>
       </modules>
     </module_system>
     <environment_variables>

--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2334,7 +2334,7 @@ This allows using a different mpirun command to launch unit tests
     <DOUT_L_ROOT>/projects/NS2345K/noresm/cases</DOUT_L_ROOT>
     <DOUT_L_HOSTNAME>login.nird.sigma2.no</DOUT_L_HOSTNAME>
     <BASELINE_ROOT>/cluster/shared/noresm/noresm_baselines</BASELINE_ROOT>
-    <CCSM_CPRNC>/cluster/shared/noresm/tools/cprnc-iompi-2020a/cprnc</CCSM_CPRNC>
+    <CCSM_CPRNC>/cluster/shared/noresm/tools/cprnc-iompi-2022a/cprnc</CCSM_CPRNC>
     <GMAKE_J>8</GMAKE_J>
     <BATCH_SYSTEM>slurm_nor</BATCH_SYSTEM>
     <SUPPORTED_BY>noresmCommunity</SUPPORTED_BY>


### PR DESCRIPTION
Same as PR #79 , but using fork to bypass branch protection on main repo.

This updates noresm2_3_develop with latest changes from noresm2_1_develop, keeping these branches identical.
Alternatively, we could remove one of these branches going forward.

Includes update also for CPRNC.

Tag after merging: `cime5.6.10_NorESM2_3_r4`

Test `TomasTorsvik:noresm2.1.2` branch returns PASS with comparison to `release-noresm2.1.1` for test suit `prealpha_noresm` https://github.com/NorESMhub/NorESM/pull/542#issuecomment-2291627016