### PR TITLE
add xml-libxml hidden module explicitly

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2364,6 +2364,7 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">NCO/5.1.9-iomkl-2022a</command>
         <command name="load">CMake/3.23.1-GCCcore-11.3.0</command>
         <command name="load">Python/3.10.4-GCCcore-11.3.0</command>
+        <command name="load">XML-LibXML/2.0207-GCCcore-11.3.0</command>
       </modules>
     </module_system>
     <environment_variables>


### PR DESCRIPTION
After betzy OS update XML-libXML is not getting loaded as part of a bundle.

@TomasTorsvik @monsieuralok  can you test this for [release-noresm2.1.2](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.1.2) and [release-noresm2.0.8](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.8), so we can checkout updated cime and bump both tags by one?
