### PR TITLE
Add configuration to run DATM/DROF with JRA repeat-year forcing for 1961

### DIFF
--- a/src/components/data_comps/datm/cime_config/config_component.xml
+++ b/src/components/data_comps/datm/cime_config/config_component.xml
@@ -10,7 +10,7 @@
        This file may have atm desc entries.
   -->
   <description modifier_mode="1">
-    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%CPLHIST][%1PT][%NYF][%IAF][%JRA]"> Data driven ATM </desc>
+    <desc atm="DATM[%QIA][%WISOQIA][%CRU][%CRUv7][%GSWP3v1][%CPLHIST][%1PT][%NYF][%IAF][%JRA][%JRARYF1961]"> Data driven ATM </desc>
     <desc option="QIA"> QIAN data set </desc>
     <desc option="WISOQIA">QIAN with water isotopes</desc>
     <desc option="CRU"> CRUNCEP data set </desc>
@@ -21,6 +21,7 @@
     <desc option="NYF">COREv2 normal year forcing</desc>
     <desc option="IAF">COREv2 interannual forcing</desc>
     <desc option="JRA">interannual JRA55 forcing</desc>
+    <desc option="JRARYF1961">JRA55 repeat year forcing (1961)</desc>
   </description>
 
   <entry id="COMP_ATM">
@@ -34,7 +35,7 @@
 
   <entry id="DATM_MODE">
     <type>char</type>
-    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CPLHIST,CORE_IAF_JRA</valid_values>
+    <valid_values>CORE2_NYF,CORE2_IAF,CLM_QIAN,CLM_QIAN_WISO,CLM1PT,CLMCRUNCEP,CLMCRUNCEPv7,CLMGSWP3v1,CPLHIST,CORE_IAF_JRA,CORE_IAF_JRARYF1961</valid_values>
     <default_value>CORE2_NYF</default_value>
     <group>run_component_datm</group>
     <file>env_run.xml</file>
@@ -45,6 +46,7 @@
       <value compset="%NYF">CORE2_NYF</value>
       <value compset="%IAF">CORE2_IAF</value>
       <value compset="%JRA">CORE_IAF_JRA</value>
+      <value compset="%JRARYF1961">CORE_IAF_JRARYF1961</value>
       <value compset="%QIA">CLM_QIAN</value>
       <value compset="%WISOQIA">CLM_QIAN_WISO</value>
       <value compset="%CRU">CLMCRUNCEP</value>
@@ -69,6 +71,7 @@
       <value compset="^RCP2_">rcp2.6</value>
       <value compset="^HIST_">trans_1850-2000</value>
       <value compset="^20TR_">trans_1850-2000</value>
+      <value compset="%JRARYF1961">clim_1850</value>
       <value compset="^20TR_DATM%JRA" cime_model="cesm">cesm2_omip2</value>
       <value compset="_DATM%CPLHIST">cplhist</value>
     </values>

--- a/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
+++ b/src/components/data_comps/datm/cime_config/namelist_definition_datm.xml
@@ -39,7 +39,8 @@
     CLM1PT		= Run with supplied single point data (force CLM)
     CORE2_NYF		= CORE2 normal year forcing (for forcing POP and CICE)
     CORE2_IAF		= CORE2 intra-annual year forcing (for forcing POP and CICE)
-    CORE_IAF_JRA		= JRA55 intra-annual year forcing (for forcing POP and CICE)
+    CORE_IAF_JRA	= JRA55 intra-annual year forcing (for forcing POP and CICE)
+    CORE_IAF_JRARYF1961= Repeat year 1961 of JRA55 for spin-up purposes
     CPLHIST     	= Streams for lnd or ocn/ice forcing used for spinup
     presaero		= Prescribed aerosol forcing
     topo		= Surface topography
@@ -1641,7 +1642,8 @@
         JRA.v1.3.v_10.TL319.2016.190528.nc
         JRA.v1.3.v_10.TL319.2017.190528.nc
         JRA.v1.3.v_10.TL319.2018.190528.nc
-      </value> 
+      </value>
+            
       <value stream="co2tseries.20tr.latbnd">fco2_datm_lat-bands_simyr_1750-2015_CMIP6_c180929.nc</value>
       <value stream="co2tseries.20tr">fco2_datm_global_simyr_1750-2014_CMIP6_c180929.nc</value>
       <value stream="co2tseries.omip2">fco2_datm_global_ssp585_simyr_1750-2020_CMIP6_c190522.nc</value>
@@ -2034,6 +2036,7 @@
       <value stream="CORE2_IAF.CORE2.ArcFactor">1948</value>
       <value stream="CORE2_IAF">1948</value>
       <value stream="CORE_IAF_JRA">1958</value>
+      <value stream="CORE_IAF_JRA" datm_mode="CORE_IAF_JRARYF1961">1</value>
       <value stream="co2tseries.20tr">1850</value>
       <value stream="co2tseries.omip2" datm_mode="CORE_IAF_JRA">1850</value>
       <value stream="co2tseries.rcp">2005</value>
@@ -2099,6 +2102,7 @@
       <value stream="CORE_IAF_JRA.NCEP.T_10">1958</value>
       <value stream="CORE_IAF_JRA.NCEP.U_10">1958</value>
       <value stream="CORE_IAF_JRA.NCEP.V_10">1958</value>
+      <value stream="CORE_IAF_JRA" datm_mode="CORE_IAF_JRARYF1961">1961</value>
       <value stream="co2tseries.20tr">1850</value>
       <value stream="co2tseries.omip2">1850</value>
       <value stream="co2tseries.rcp">2005</value>
@@ -2163,6 +2167,7 @@
       <value stream="CORE_IAF_JRA.NCEP.T_10">2018</value>
       <value stream="CORE_IAF_JRA.NCEP.U_10">2018</value>
       <value stream="CORE_IAF_JRA.NCEP.V_10">2018</value>
+      <value stream="CORE_IAF_JRA" datm_mode="CORE_IAF_JRARYF1961">1961</value>
       <value stream="co2tseries.20tr">2014</value>
       <value stream="co2tseries.omip2">2019</value>
       <value stream="co2tseries.rcp">2500</value>
@@ -2211,7 +2216,7 @@
     <type>char</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>
-    <valid_values>CLMNCEP,COPYALL,CORE2_NYF,CORE2_IAF,CORE_IAF_JRA,NULL</valid_values>
+    <valid_values>CLMNCEP,COPYALL,CORE2_NYF,CORE2_IAF,CORE_IAF_JRA,CORE_IAF_JRARYF1961,NULL</valid_values>
     <desc>
       general method that operates on the data.  this is generally
       implemented in the data models but is set in the strdata method for
@@ -2249,6 +2254,8 @@
       Clm Dyn doi 10.1007/s00382-008-0441-3.
       datamode = "CORE_IAF_JRA"
       JRA55 intra-annual year forcing
+      datamode = "CORE_IAF_JRARYF1961"
+      Repeat year 1961 of JRA55 forcing for spin-up
       datamode = "CLMNCEP"
       In conjunction with NCEP climatological atmosphere data, provides the
       atmosphere forcing favored by the Land Model Working Group when
@@ -2263,6 +2270,7 @@
       <value datm_mode="CORE2_NYF">CORE2_NYF</value>
       <value datm_mode="CORE2_IAF">CORE2_IAF</value>
       <value datm_mode="CORE_IAF_JRA">CORE_IAF_JRA</value>
+      <value datm_mode="CORE_IAF_JRARYF1961">CORE_IAF_JRARYF1961</value>
       <value datm_mode="CPLHIST">COPYALL</value>
     </values>
   </entry>

--- a/src/components/data_comps/drof/cime_config/config_component.xml
+++ b/src/components/data_comps/drof/cime_config/config_component.xml
@@ -13,12 +13,13 @@
   -->
 
   <description modifier_mode="1">
-    <desc rof="DROF[%NULL][%NYF][%IAF][%CPLHIST][%JRA]">Data runoff model</desc>
+    <desc rof="DROF[%NULL][%NYF][%IAF][%CPLHIST][%JRA][%JRARYF1961]">Data runoff model</desc>
     <desc option="NULL">NULL mode</desc>
     <desc option="NYF" >COREv2 normal year forcing:</desc>
     <desc option="IAF" >COREv2 interannual year forcing:</desc>
     <desc option="CPLHIST">CPLHIST mode:</desc>
     <desc option="JRA">JRA55 interannual forcing</desc>
+    <desc option="JRARYF1961">JRA55 repeat year forcing (1961)</desc>
   </description>
 
   <entry id="COMP_ROF">
@@ -32,7 +33,7 @@
 
   <entry id="DROF_MODE">
     <type>char</type>
-    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,IAF_JRA,NULL</valid_values>
+    <valid_values>CPLHIST,DIATREN_ANN_RX1,DIATREN_IAF_RX1,IAF_JRA,IAF_JRARYF1961,NULL</valid_values>
     <default_value>DIATREN_ANN_RX1</default_value>
     <values match="last">
       <value compset="_DROF%NULL">NULL</value>
@@ -40,6 +41,7 @@
       <value compset="_DROF%IAF" >DIATREN_IAF_RX1</value>
       <value compset="_DROF%CPLHIST">CPLHIST</value>
       <value compset="_DROF%JRA" >IAF_JRA</value>
+      <value compset="_DROF%JRARYF1961">IAF_JRARYF1961</value>
       <value compset=".+" grid="r%null">NULL</value> <!-- overwrites above if runoff grid is null -->
     </values>
     <group>run_component_drof</group>

--- a/src/components/data_comps/drof/cime_config/namelist_definition_drof.xml
+++ b/src/components/data_comps/drof/cime_config/namelist_definition_drof.xml
@@ -244,6 +244,7 @@
       <value stream="rof.diatren_ann_rx1">1</value>
       <value stream="rof.diatren_iaf_rx1">1948</value>
       <value stream="rof.iaf_jra">1958</value>
+      <value stream="rof.iaf_jra" drof_mode="IAF_JRARYF1961">1</value>
       <value stream="rof.cplhist">$DROF_CPLHIST_YR_ALIGN</value>
     </values>
   </entry>
@@ -257,6 +258,7 @@
       <value stream="rof.diatren_ann_rx1">1</value>
       <value stream="rof.diatren_iaf_rx1">1948</value>
       <value stream="rof.iaf_jra">1958</value>
+      <value stream="rof.iaf_jra" drof_mode="IAF_JRARYF1961">1961</value>
       <value stream="rof.cplhist">$DROF_CPLHIST_YR_START</value>
     </values>
   </entry>
@@ -270,6 +272,7 @@
       <value stream="rof.diatren_ann_rx1">1</value>
       <value stream="rof.diatren_iaf_rx1">2009</value>
       <value stream="rof.iaf_jra">2018</value>
+      <value stream="rof.iaf_jra" drof_mode="IAF_JRARYF1961">1961</value>
       <value stream="rof.cplhist">$DROF_CPLHIST_YR_END</value>
     </values>
   </entry>


### PR DESCRIPTION
This PR adds the configuration for DATM and DROF to run a "repeat-year forcing" based on JRA v1.3 forcing. The configurations are almost identical to the JRA forcing except that `strm_year_align`, `strm_year_start`, and `strm_year_end` are set to 1, 1961, and 1961, respectively.

Test suite: I am currently running 400 years of JRARYF1961 
Test baseline: I am comparing against 400 years of JRA forcing 
Test namelist changes: `strm_year_align`, `strm_year_start`, and `strm_year_end` are set to 1, 1961, and 1961, respectively
Test status: The diagnostics of my test runs can be found here:
https://ns2345k.web.sigma2.no/datalake/diagnostics/noresm/jschwing/NOIIAJRAOC1850_TL319_tn14_42/
https://ns2345k.web.sigma2.no/datalake/diagnostics/noresm/jschwing/NOINYJRARYF1961OC_TL319_tn14_42/

This PR is related to https://github.com/NorESMhub/BLOM/pull/431/files

User interface changes?: The new configurations are activated via new compsets in BLOM
