### PR TITLE
cime5.6.10_NorESM2_3_r6: Fix CLMFORC paths on betzy and fram

### DIFF
--- a/config/cesm/machines/config_machines.xml
+++ b/config/cesm/machines/config_machines.xml
@@ -2266,7 +2266,7 @@ This allows using a different mpirun command to launch unit tests
     <MPILIBS>impi</MPILIBS>
     <CIME_OUTPUT_ROOT>/cluster/work/users/$USER/noresm</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/cluster/shared/noresm/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>UNSET</DIN_LOC_ROOT_CLMFORC>
+    <DIN_LOC_ROOT_CLMFORC>/cluster/shared/noresm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>/cluster/work/users/$USER/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_ROOT>/projects/NS2345K/noresm/cases</DOUT_L_ROOT>
     <DOUT_L_HOSTNAME>login.nird.sigma2.no</DOUT_L_HOSTNAME>
@@ -2329,7 +2329,7 @@ This allows using a different mpirun command to launch unit tests
     <MPILIBS compiler="intel" >openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>/cluster/work/users/$USER/noresm</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/cluster/shared/noresm/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>UNSET</DIN_LOC_ROOT_CLMFORC>
+    <DIN_LOC_ROOT_CLMFORC>/cluster/shared/noresm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>/cluster/work/users/$USER/archive/$CASE</DOUT_S_ROOT>
     <DOUT_L_ROOT>/projects/NS2345K/noresm/cases</DOUT_L_ROOT>
     <DOUT_L_HOSTNAME>login.nird.sigma2.no</DOUT_L_HOSTNAME>


### PR DESCRIPTION
Added a default path to the forcing directory for I compsets with CLM needs a  to run out of the box

Tests: Checked file format and directory availability on Betzy and Fram
Test baseline: no need
Test namelist changes: nothing
Test status: NA

Fixes NA

User interface changes?: No
Update gh-pages html (Y/N)?: No