### PR TITLE
Include suport for separate hamocc test list

### DIFF
--- a/config/cesm/config_files.xml
+++ b/config/cesm/config_files.xml
@@ -126,6 +126,7 @@
     <values>
       <value component="pop"       >$SRCROOT/components/pop/</value>
       <value component="blom"      >$SRCROOT/components/blom/</value>
+      <value component="hamocc"    >$SRCROOT/components/blom/</value>
       <value component="docn"      >$CIMEROOT/src/components/data_comps/docn</value>
       <value component="socn"      >$CIMEROOT/src/components/stub_comps/socn</value>
       <value component="xocn"      >$CIMEROOT/src/components/xcpl_comps/xocn</value>
@@ -323,6 +324,7 @@
       <value component="rtm"      >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testlist_rtm.xml</value>
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testlist_mosart.xml</value>
       <value component="blom"     >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testlist_blom.xml</value>
+      <value component="hamocc"   >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testlist_hamocc.xml</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>
@@ -344,6 +346,7 @@
       <value component="mosart"   >$COMP_ROOT_DIR_ROF/cime_config/testdefs/testmods_dirs</value>
       <value component="pop"      >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
       <value component="blom"     >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
+      <value component="hamocc"   >$COMP_ROOT_DIR_OCN/cime_config/testdefs/testmods_dirs</value>
     </values>
     <group>case_last</group>
     <file>env_case.xml</file>


### PR DESCRIPTION
This change will allow us to define a separate test list for iHAMOCC.

Test suite: None
Test baseline: None
Test namelist changes: aux_hamocc_noresm
Test status: [bit for bit, roundoff, climate changing]

Fixes [CIME Github issue #]
- #92 
- https://github.com/NorESMhub/NorESM/issues/616

User interface changes?:

Update gh-pages html (Y/N)?:
