### PR TITLE
Archive iHAMOCC inventory file hbgci

### DIFF
--- a/config/cesm/config_archive.xml
+++ b/config/cesm/config_archive.xml
@@ -130,7 +130,7 @@
       <rest_file_extension>r</rest_file_extension>
       <rest_file_extension>rbgc</rest_file_extension>
       <hist_file_extension>h[dmy]\d*.*\.nc$</hist_file_extension>
-      <hist_file_extension>hbgc[dmy]\d*.*\.nc$</hist_file_extension>
+      <hist_file_extension>hbgc[idmy]\d*.*\.nc$</hist_file_extension>
       <rest_history_varname>unset</rest_history_varname>
       <rpointer>
         <rpointer_file>rpointer$NINST_STRING.ocn</rpointer_file>


### PR DESCRIPTION
This change includes the iHAMOCC inventory files `hbgci` in the list of history files, to be copied to the BLOM archive folder.