### PR TITLE
Update Makefile and mkDepends

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -116,6 +116,24 @@ ifdef USER_INCLDIR
   INCLDIR += $(USER_INCLDIR)
 endif
 
+FTORCH_DIR = $(SHAREDLIBROOT)/$(SHAREDPATH)/FTorch/
+ifneq "$(wildcard $(FTORCH_DIR) )" ""
+  INCLDIR  += -I$(FTORCH_DIR)/modules -I$(FTORCH_DIR)
+  ifeq ($(strip $(COMPILER)),nag)
+    SLIBS  +=  -Wl,-Wl,,-rpath=$(FTORCH_DIR) -L$(FTORCH_DIR) -lftorch_wrapper
+  else
+    SLIBS  +=  -Wl,-rpath,$(FTORCH_DIR) -L$(FTORCH_DIR) -lftorch_wrapper
+  endif
+endif
+ifeq ($(strip $(USE_FTORCH)), TRUE)
+  CPPDEFS  += -DUSE_FTORCH
+  ifeq ($(strip $(COMPILER)),nag)
+    SLIBS  +=  -Wl,-Wl,,-rpath=$(TORCH_DIR)/lib -L$(TORCH_DIR)/lib -ltorch_cpu -lc10 -lstdc++ -Wl,-rpath,$(FTORCH_DIR)/src -L$(FTORCH_DIR)/src -lftorch
+  else
+    SLIBS  +=  -Wl,-rpath,$(TORCH_DIR)/lib -L$(TORCH_DIR)/lib -ltorch_cpu -lc10 -lstdc++ -Wl,-rpath,$(FTORCH_DIR)/src -L$(FTORCH_DIR)/src -lftorch
+  endif
+endif
+
 ifdef FSTDLIB_PKGCONFIG
   STDLIB_INC  := `pkg-config --cflags fortran_stdlib`
   STDLIB_LIBS := `pkg-config --libs fortran_stdlib`
@@ -569,7 +587,6 @@ endif
 
 endif
 
-
 # System libraries (netcdf, mpi, pnetcdf, esmf, trilinos, etc.)
 ifeq ($(NETCDF_SEPARATE), FALSE)
    ifeq (,$(findstring $(LIB_NETCDF),$(SLIBS)))
@@ -731,6 +748,7 @@ CMAKE_ENV_VARS += CC=$(CC) \
 		  FC=$(FC) \
 		  LDFLAGS="$(LDFLAGS)"
 
+F90_LDFLAGS += $(FFLAGS)
 
 # We declare GLCMakefile to be a phony target so that cmake is
 # always rerun whenever invoking 'make GLCMakefile'; this is
@@ -743,6 +761,10 @@ GLCMakefile:
 $(PIO_LIBDIR)/Makefile:
 	cd $(PIO_LIBDIR); \
 	$(CMAKE_ENV_VARS) cmake $(CMAKE_OPTS) $(PIO_SRC_DIR)
+
+FTMakefile:
+	cd $(FTORCH_DIR)
+	$(CMAKE_ENV_VARS) cmake $(CMAKE_OPTS) $(FTORCH_SRC_DIR)
 
 #-------------------------------------------------------------------------------
 # Build & include dependency files
@@ -847,6 +869,10 @@ endif
 ifdef COSP_LIBDIR
   ifeq ($(CIME_MODEL),cesm)
     ULIBDEP += $(COSP_LIBDIR)/libcosp.a
+    # Additionally include RTTOV if asked via CAM_CONFIG_OPTS.
+    ifeq ($(findstring -rttov,$(CAM_CONFIG_OPTS)),-rttov)
+      ULIBDEP += $(COSP_LIBDIR)/librttov_wrapper.a $(COSP_LIBDIR)/librttov_mw_scatt.a $(COSP_LIBDIR)/librttov_brdf_atlas.a $(COSP_LIBDIR)/librttov_emis_atlas.a  $(COSP_LIBDIR)/librttov_other.a $(COSP_LIBDIR)/librttov_parallel.a $(COSP_LIBDIR)/librttov_coef_io.a $(COSP_LIBDIR)/librttov_hdf.a $(COSP_LIBDIR)/librttov_main.a
+    endif
   endif
 endif
 

--- a/CIME/Tools/mkDepends
+++ b/CIME/Tools/mkDepends
@@ -185,8 +185,8 @@ foreach $f (@src) {
     my $file_path = find_file($f);
     open(FH, $file_path)  or die "Can't open $file_path: $!\n";
     while ( <FH> ) {
-	# Search for module definitions.
-	if ( /^\s*MODULE\s+(\w+)\s*(\!.*)?$/i ) {
+        # Search for module and submodule definitions.
+        if ( /^\s*MODULE\s+(\w+)\s*(\!.*)?$/i || /^\s*SUBMODULE\s*\(\s*\w+\s*(?:\:\s*\w+\s*)?\)\s*(\w+)/i ) {
 	    ($mod = $1) =~ tr/A-Z/a-z/;
             if ( defined $module_files{$mod} ) {
                 die "Duplicate definitions of module $mod in $module_files{$mod} and $name: $!\n";
@@ -371,20 +371,19 @@ foreach $f (sort keys %file_modules) {
         $f =~ /(.+)\./;
 	$file = $1;
     }
-    $target = $obj_dir."$file.o";
-    print "$target : $f @{$file_modules{$f}} @{$file_includes{$f}} $additional_file \n";
+    my $target = $obj_dir."$file.o";
+    print join(" ", grep { defined } ("$target :", $f, @{$file_modules{$f}}, @{$file_includes{$f}}, $additional_file))."\n";
 }
 
 print "# The following section relates each module to the corresponding file.\n";
 $target = mangle_modfile("%");
-print "$target : \n";
+print "$target :\n";
 print "\t\@\:\n";
 
 foreach $mod (sort keys %modules_used) {
     my $mod_fname = $obj_dir.mangle_modfile($mod);
     my $obj_fname = $obj_dir.$module_files{$mod}.".o";
     print "$mod_fname : $obj_fname\n";
-
 }
 
 #--------------------------------------------------------------------------------------
@@ -427,22 +426,28 @@ sub find_dependencies {
 	    push @incs, $include;
 	    undef $include;
 	}
-	# Search for module dependencies.
-	elsif ( /^\s*USE(?:\s+|\s*\:\:\s*|\s*,\s*non_intrinsic\s*\:\:\s*)(\w+)/i ) {
-	    # Return dependency in the form of a .mod file
-	    ($module = $1) =~ tr/A-Z/a-z/;
-	    if ( defined $module_files{$module} ) {
-		# Check for circular dependency
-		unless ("$module_files{$module}.o" eq $target) {
-                    $modules_used{$module} = ();
-                    push @mods, "$obj_dir".mangle_modfile($module);
-		}
-	    }
-            # If we already have a .mod file around.
-            elsif ( defined $trumod_files{$module} ) {
-                push @mods, "$obj_dir".mangle_modfile($trumod_files{$module});
+        # Search for module dependencies.
+        # Module dependencies are extracted from the following patterns:
+        # 1. The "module-name" in a Fortran "USE [[, module-nature] ::] module-name" statement
+        # 2. The "ancestor-module-name" and "parent-submodule-name" in a Fortran "SUBMODULE (ancestor-module-name [: parent-submodule-name]) submodule-name" statement
+        elsif ( /^\s*USE(?:\s+|\s*\:\:\s*|\s*,\s*non_intrinsic\s*\:\:\s*)(\w+)/i || /^\s*SUBMODULE\s*\(\s*(\w+)\s*(?:\:\s*(\w+)\s*)?\)\s*\w+/i ) {
+            # There might be one or two matches from the regexes above.
+            for my $match (grep { defined } ($1, $2)) {
+                # Return dependency in the form of a .mod file.
+                (my $module = $match) =~ tr/A-Z/a-z/;
+                if ( defined $module_files{$module} ) {
+                    # Check for circular dependency.
+                    unless ("$module_files{$module}.o" eq $target) {
+                        $modules_used{$module} = ();
+                        push @mods, "$obj_dir".mangle_modfile($module);
+                    }
+                }
+                # If we already have a .mod file around.
+                elsif ( defined $trumod_files{$module} ) {
+                    push @mods, "$obj_dir".mangle_modfile($trumod_files{$module});
+                }
             }
-	}
+        }
     }
     close( FH );
     return (\@mods, \@incs);
@@ -470,16 +475,18 @@ sub find_file {
 
 sub rm_duplicates {
 
-# Return a list with duplicates removed.
+# Return a list with duplicates removed, preserving the original order.
 
-    my ($in) = @_;       # input arrary reference
-    my @out = ();
-    my $i;
-    my %h = ();
-    foreach $i (@$in) {
-	$h{$i} = '';
+    my ($in) = @_;
+    my @out  = ();
+    my %seen = ();
+
+    for my $item (@$in) {
+        unless ($seen{$item}++) {
+            push @out, $item;
+        }
     }
-    @out = keys %h;
+
     return \@out;
 }
 


### PR DESCRIPTION
Update mkDepends and Makefile to be able to handle Fortran submodules

- These files are identical to the ones in ESMCI/master.
- CAM has started using Fortran submodules (a Fortran 2008 feature).
- Updated Makefile also contains capability of building FTorch library

Test suite: aux_cam_noresm
Test baseline: NA
Test namelist changes: NA
Test status: bit for bit
User interface changes?: NA

Update gh-pages html (Y/N)?: N
