### PR TITLE
updated to cime6.1.143

### DIFF
--- a/CIME/data/templates/gitignore.template
+++ b/CIME/data/templates/gitignore.template
@@ -5,8 +5,8 @@ run
 *.log
 
 # queueing system output files
-run.*.o\d+
-st_archive.*.o\d+
+*.o\d+
+*.o\d+
 
 #python files
 __pycache__/


### PR DESCRIPTION
The only difference with ESMCI 6.1.143 is the external link for CIME/non_py/cprnc